### PR TITLE
moar asyncio support, test infra improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 *[CalVer, YY.month.patch](https://calver.org/)*
 
-## 24.3.8
+## 24.3.1
 - Removed TRIO117, MultiError removed in trio 0.24.0
 - Renamed the library from flake8-trio to flake8-async, to indicate the checker supports more than just `trio`.
 - Renamed all error codes from TRIOxxx to ASYNCxxx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
 # Changelog
 *[CalVer, YY.month.patch](https://calver.org/)*
 
-## Future
+## 24.3.8
 - Removed TRIO117, MultiError removed in trio 0.24.0
 - Renamed the library from flake8-trio to flake8-async, to indicate the checker supports more than just `trio`.
 - Renamed all error codes from TRIOxxx to ASYNCxxx
 - Renamed the binary from flake8-trio to flake8-async
 - Lots of internal renaming.
-- Added asyncio support for ASYNC106
+- Added asyncio support for several error codes
 - added `--library`
 
 ## 23.5.1

--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ Note: 22X, 23X and 24X has not had asyncio-specific suggestions written.
 - **ASYNC210**: Sync HTTP call in async function, use `httpx.AsyncClient`. This and the other ASYNC21x checks look for usage of `urllib3` and `httpx.Client`, and recommend using `httpx.AsyncClient` as that's the largest http client supporting anyio/trio.
 - **ASYNC211**: Likely sync HTTP call in async function, use `httpx.AsyncClient`. Looks for `urllib3` method calls on pool objects, but only matching on the method signature and not the object.
 - **ASYNC212**: Blocking sync HTTP call on httpx object, use httpx.AsyncClient.
-- **ASYNC220**: Sync process call in async function, use `await nursery.start([trio|anyio].run_process, ...)`.
-- **ASYNC221**: Sync process call in async function, use `await [trio|anyio].run_process(...)`.
-- **ASYNC222**: Sync `os.*` call in async function, wrap in `await [trio|anyio].to_thread.run_sync()`.
-- **ASYNC230**: Sync IO call in async function, use `[trio|anyio].open_file(...)`.
-- **ASYNC231**: Sync IO call in async function, use `[trio|anyio].wrap_file(...)`.
+- **ASYNC220**: Sync process call in async function, use `await nursery.start([trio|anyio].run_process, ...)`. `asyncio` users can use [`asyncio.create_subprocess_[exec/shell]`](https://docs.python.org/3/library/asyncio-subprocess.html).
+- **ASYNC221**: Sync process call in async function, use `await [trio|anyio].run_process(...)`. `asyncio` users can use [`asyncio.create_subprocess_[exec/shell]`](https://docs.python.org/3/library/asyncio-subprocess.html).
+- **ASYNC222**: Sync `os.*` call in async function, wrap in `await [trio|anyio].to_thread.run_sync()`. `asyncio` users can use [`asyncio.loop.run_in_executor`](https://docs.python.org/3/library/asyncio-subprocess.html).
+- **ASYNC230**: Sync IO call in async function, use `[trio|anyio].open_file(...)`. `asyncio` users need to use a library such as [aiofiles](https://pypi.org/project/aiofiles/), or switch to [anyio](https://github.com/agronholm/anyio).
+- **ASYNC231**: Sync IO call in async function, use `[trio|anyio].wrap_file(...)`. `asyncio` users need to use a library such as [aiofiles](https://pypi.org/project/aiofiles/), or switch to [anyio](https://github.com/agronholm/anyio).
 - **ASYNC232**: Blocking sync call on file object, wrap the file object in `[trio|anyio].wrap_file()` to get an async file object.
-- **ASYNC240**: Avoid using `os.path` in async functions, prefer using `[trio|anyio].Path` objects.
+- **ASYNC240**: Avoid using `os.path` in async functions, prefer using `[trio|anyio].Path` objects. `asyncio` users should consider [aiopath](https://pypi.org/project/aiopath) or [anyio](https://github.com/agronholm/anyio).
 
 ### Warnings disabled by default
 - **ASYNC900**: Async generator without `@asynccontextmanager` not allowed. You might want to enable this on a codebase since async generators are inherently unsafe and cleanup logic might not be performed. See https://github.com/python-trio/flake8-async/issues/211 and https://discuss.python.org/t/using-exceptiongroup-at-anthropic-experience-report/20888/6 for discussion.

--- a/flake8_async/__init__.py
+++ b/flake8_async/__init__.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
 
 
 # CalVer: YY.month.patch, e.g. first release of July 2022 == "22.7.1"
-__version__ = "23.5.1"
+__version__ = "24.3.8"
 
 
 # taken from https://github.com/Zac-HD/shed

--- a/flake8_async/__init__.py
+++ b/flake8_async/__init__.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
 
 
 # CalVer: YY.month.patch, e.g. first release of July 2022 == "22.7.1"
-__version__ = "24.3.8"
+__version__ = "24.3.1"
 
 
 # taken from https://github.com/Zac-HD/shed

--- a/flake8_async/base.py
+++ b/flake8_async/base.py
@@ -83,7 +83,7 @@ class Error:
 
     def cmp(self):
         # column may be ignored/modified when autofixing, so sort on that last
-        return self.line, self.code, self.args, self.col
+        return self.line, self.code, self.args, self.message, self.col
 
     # for sorting in tests
     def __lt__(self, other: Error) -> bool:

--- a/flake8_async/visitors/visitors.py
+++ b/flake8_async/visitors/visitors.py
@@ -171,6 +171,7 @@ class Visitor113(Flake8AsyncVisitor):
                 in (
                     "trio.Nursery",
                     "anyio.TaskGroup",
+                    "asyncio.TaskGroup",
                 )
             )
 

--- a/flake8_async/visitors/visitors.py
+++ b/flake8_async/visitors/visitors.py
@@ -93,7 +93,9 @@ class Visitor112(Flake8AsyncVisitor):
             var_name = item.optional_vars.id
 
             # check for trio.open_nursery
-            nursery = get_matching_call(item.context_expr, "open_nursery")
+            nursery = get_matching_call(
+                item.context_expr, "open_nursery", base=("trio",)
+            )
 
             # `isinstance(..., ast.Call)` is done in get_matching_call
             body_call = cast("ast.Call", node.body[0].value)
@@ -209,7 +211,7 @@ class Visitor114(Flake8AsyncVisitor):
             self.error(node, node.name)
 
 
-# Suggests replacing all `trio.sleep(0)` with the more suggestive
+# Suggests replacing all `[trio|anyio].sleep(0)` with the more suggestive
 # `trio.lowlevel.checkpoint()`
 @error_class
 class Visitor115(Flake8AsyncVisitor):

--- a/tests/autofix_files/async100.py
+++ b/tests/autofix_files/async100.py
@@ -1,6 +1,6 @@
 # type: ignore
 # AUTOFIX
-# NOASYNCIO
+# ASYNCIO_NO_ERROR # timeout primitives are named differently in asyncio
 
 import trio
 

--- a/tests/autofix_files/async100_simple_autofix.py
+++ b/tests/autofix_files/async100_simple_autofix.py
@@ -1,4 +1,4 @@
-# NOASYNCIO
+# ASYNCIO_NO_ERROR - no asyncio.move_on_after
 # AUTOFIX
 import trio
 

--- a/tests/autofix_files/noqa.py
+++ b/tests/autofix_files/noqa.py
@@ -1,6 +1,5 @@
 # AUTOFIX
-# NOANYIO # TODO
-# NOASYNCIO
+# NOASYNCIO - does not trigger on ASYNC100
 # ARG --enable=ASYNC100,ASYNC911
 from typing import Any
 

--- a/tests/autofix_files/noqa_testing.py
+++ b/tests/autofix_files/noqa_testing.py
@@ -1,5 +1,4 @@
 # AUTOFIX
-# NOANYIO # TODO
 # ARG --enable=ASYNC911
 import trio
 

--- a/tests/eval_files/anyio_trio.py
+++ b/tests/eval_files/anyio_trio.py
@@ -1,7 +1,6 @@
 # type: ignore
 # ARG --enable=ASYNC220
 # NOTRIO
-# NOASYNCIO
 # set base library so trio doesn't get replaced when running with anyio
 # BASE_LIBRARY anyio
 

--- a/tests/eval_files/async100.py
+++ b/tests/eval_files/async100.py
@@ -1,6 +1,6 @@
 # type: ignore
 # AUTOFIX
-# NOASYNCIO
+# ASYNCIO_NO_ERROR # timeout primitives are named differently in asyncio
 
 import trio
 

--- a/tests/eval_files/async100_asyncio.py
+++ b/tests/eval_files/async100_asyncio.py
@@ -1,0 +1,23 @@
+# TRIO_NO_ERROR
+# ANYIO_NO_ERROR
+# BASE_LIBRARY asyncio
+# ASYNCIO_NO_ERROR # TODO
+
+import asyncio
+import asyncio.timeouts
+
+
+async def foo():
+    # py>=3.11 re-exports these in the main asyncio namespace
+    with asyncio.timeout_at(10):  # type: ignore[attr-defined]
+        ...
+    with asyncio.timeout_at(10):  # type: ignore[attr-defined]
+        ...
+    with asyncio.timeout(10):  # type: ignore[attr-defined]
+        ...
+    with asyncio.timeouts.timeout_at(10):
+        ...
+    with asyncio.timeouts.timeout_at(10):
+        ...
+    with asyncio.timeouts.timeout(10):
+        ...

--- a/tests/eval_files/async100_noautofix.py
+++ b/tests/eval_files/async100_noautofix.py
@@ -1,4 +1,4 @@
-# NOASYNCIO
+# ASYNCIO_NO_ERROR - no asyncio.move_on_after
 import trio
 
 

--- a/tests/eval_files/async100_simple_autofix.py
+++ b/tests/eval_files/async100_simple_autofix.py
@@ -1,4 +1,4 @@
-# NOASYNCIO
+# ASYNCIO_NO_ERROR - no asyncio.move_on_after
 # AUTOFIX
 import trio
 

--- a/tests/eval_files/async101.py
+++ b/tests/eval_files/async101.py
@@ -1,4 +1,6 @@
-# ASYNCIO_NO_ERROR - no nursery/cancelscope in asyncio
+# ASYNCIO_NO_ERROR - nursery/cancelscope in asyncio is called taskgroup/timeout
+# Note: this one *shouldn't* be giving the same errors for anyio (but it currently does)
+# since it has TaskGroups instead of nurseries. #TODO #215
 # type: ignore
 import contextlib
 import contextlib as bla

--- a/tests/eval_files/async101.py
+++ b/tests/eval_files/async101.py
@@ -1,4 +1,4 @@
-# NOASYNCIO
+# ASYNCIO_NO_ERROR - no nursery/cancelscope in asyncio
 # type: ignore
 import contextlib
 import contextlib as bla

--- a/tests/eval_files/async102.py
+++ b/tests/eval_files/async102.py
@@ -1,6 +1,5 @@
 # type: ignore
-# NOASYNCIO
-# asyncio has different mechanisms for shielded scopes, so would raise additional errors in this file.
+# NOASYNCIO # TODO: support asyncio shields
 from contextlib import asynccontextmanager
 
 import trio

--- a/tests/eval_files/async103.py
+++ b/tests/eval_files/async103.py
@@ -1,4 +1,3 @@
-# NOASYNCIO
 # ARG --enable=ASYNC103,ASYNC104
 
 from typing import Any

--- a/tests/eval_files/async103_no_104.py
+++ b/tests/eval_files/async103_no_104.py
@@ -1,4 +1,3 @@
-# NOASYNCIO
 # ARG --enable=ASYNC103
 # check that partly disabling a visitor works
 from typing import Any

--- a/tests/eval_files/async104.py
+++ b/tests/eval_files/async104.py
@@ -1,5 +1,4 @@
 # ARG --enable=ASYNC103,ASYNC104
-# NOASYNCIO
 try:
     ...
 # raise different exception

--- a/tests/eval_files/async105.py
+++ b/tests/eval_files/async105.py
@@ -1,5 +1,5 @@
-# NOANYIO
-# NOASYNCIO
+# ANYIO_NO_ERROR # not supported, and no plans to
+# ASYNCIO_NO_ERROR # not supported, and no plans to
 from typing import Any
 from collections.abc import Coroutine
 

--- a/tests/eval_files/async109.py
+++ b/tests/eval_files/async109.py
@@ -1,5 +1,4 @@
 # type: ignore
-# NOASYNCIO
 import trio
 import trio as anything
 

--- a/tests/eval_files/async110.py
+++ b/tests/eval_files/async110.py
@@ -1,5 +1,5 @@
 # type: ignore
-# NOASYNCIO
+# ASYNCIO_NO_ERROR - not yet supported # TODO
 import trio
 import trio as noerror
 

--- a/tests/eval_files/async111.py
+++ b/tests/eval_files/async111.py
@@ -1,5 +1,7 @@
 # type: ignore
-# NOASYNCIO
+# ASYNC111: Variable, from context manager opened inside nursery, passed to start[_soon] might be invalidly accessed while in use, due to context manager closing before the nursery. This is usually a bug, and nurseries should generally be the inner-most context manager.
+# It's possible there's an equivalent asyncio construction/gotcha, but methods are differently named, so this file will not raise any errors
+# ASYNCIO_NO_ERROR # no nurseries in asyncio. Though maybe the bug is relevant for TaskGroups
 from typing import Any
 
 import trio

--- a/tests/eval_files/async112.py
+++ b/tests/eval_files/async112.py
@@ -1,5 +1,7 @@
 # type: ignore
-# NOASYNCIO
+# ASYNC112: Nursery body with only a call to nursery.start[_soon] and not passing itself as a parameter can be replaced with a regular function call.
+# ASYNCIO_NO_ERROR - # TODO: expand check to work with asyncio.TaskGroup
+# ANYIO_NO_ERROR - # TODO: expand check to work with anyio.TaskGroup
 import functools
 from functools import partial
 

--- a/tests/eval_files/async113.py
+++ b/tests/eval_files/async113.py
@@ -1,11 +1,11 @@
 # mypy: disable-error-code="arg-type,attr-defined"
-# NOASYNCIO
+# NOASYNCIO - with two "base libraries" this file will raise errors even if substituting one of them
 from contextlib import asynccontextmanager
 
 import anyio
 import trio
 
-# NOANYIO - requires no substitution check
+# NOANYIO - this file checks both libraries
 
 
 @asynccontextmanager

--- a/tests/eval_files/async113.py
+++ b/tests/eval_files/async113.py
@@ -1,11 +1,14 @@
 # mypy: disable-error-code="arg-type,attr-defined"
-# NOASYNCIO - with two "base libraries" this file will raise errors even if substituting one of them
 from contextlib import asynccontextmanager
 
 import anyio
 import trio
 
-# NOANYIO - this file checks both libraries
+# set base library to anyio, so we can replace anyio->asyncio and get correct errors
+# BASE_LIBRARY anyio
+
+# NOTRIO - replacing anyio->trio would give mismatching errors.
+# This file tests basic trio errors, and async113_trio checks trio-specific errors
 
 
 @asynccontextmanager
@@ -14,9 +17,6 @@ async def foo():
         bar.start_soon(trio.run_process)  # ASYNC113: 8
     async with trio.open_nursery() as bar:
         bar.start_soon(trio.run_process)  # ASYNC113: 8
-
-    async with anyio.create_task_group() as bar_tg:
-        bar_tg.start_soon(anyio.run_process)  # ASYNC113: 8
 
     boo: trio.Nursery = ...  # type: ignore
     boo.start_soon(trio.run_process)  # ASYNC113: 4

--- a/tests/eval_files/async113_anyio.py
+++ b/tests/eval_files/async113_anyio.py
@@ -1,0 +1,12 @@
+# mypy: disable-error-code="arg-type"
+from contextlib import asynccontextmanager
+
+import anyio
+
+
+@asynccontextmanager
+async def foo():
+    # create_task_group only exists in anyio
+    async with anyio.create_task_group() as bar_tg:
+        bar_tg.start_soon(anyio.run_process)  # ASYNC113: 8
+    yield

--- a/tests/eval_files/async113_trio.py
+++ b/tests/eval_files/async113_trio.py
@@ -1,5 +1,5 @@
 # mypy: disable-error-code="arg-type,call-overload,misc"
-# NOASYNCIO
+# ASYNC113: Using nursery.start_soon in __aenter__ doesn't wait for the task to begin. Consider replacing with nursery.start.
 import contextlib
 import contextlib as arbitrary_import_alias_for_contextlib
 import functools
@@ -11,7 +11,9 @@ from typing import Any
 import trio
 
 # ARG --startable-in-context-manager=custom_startable_function
-# NOANYIO
+
+# ANYIO_NO_ERROR - anyio uses TaskGroups, not nurseries
+# ASYNCIO_NO_ERROR - no nurseries in asyncio
 
 
 @asynccontextmanager

--- a/tests/eval_files/async113_trio.py
+++ b/tests/eval_files/async113_trio.py
@@ -12,8 +12,8 @@ import trio
 
 # ARG --startable-in-context-manager=custom_startable_function
 
-# ANYIO_NO_ERROR - anyio uses TaskGroups, not nurseries
-# ASYNCIO_NO_ERROR - no nurseries in asyncio
+# ANYIO_NO_ERROR - anyio uses TaskGroups. Checked in async113.py & async113_anyio.py
+# ASYNCIO_NO_ERROR - asyncio uses TaskGroups. Checked in async113.py
 
 
 @asynccontextmanager

--- a/tests/eval_files/async115.py
+++ b/tests/eval_files/async115.py
@@ -1,5 +1,5 @@
 # type: ignore
-# NOASYNCIO
+# ASYNCIO_NO_ERROR # no asyncio.lowlevel.checkpoint()
 import time
 
 import trio

--- a/tests/eval_files/async116.py
+++ b/tests/eval_files/async116.py
@@ -1,5 +1,5 @@
 # type: ignore
-# NOASYNCIO
+# ASYNCIO_NO_ERROR - no asyncio.sleep_forever, so check intentionally doesn't trigger.
 import math
 from math import inf
 

--- a/tests/eval_files/async118.py
+++ b/tests/eval_files/async118.py
@@ -1,7 +1,8 @@
-# NOTRIO
-# NOASYNCIO
-# This raises the same errors on trio/asyncio, which is a bit silly, but inconsequential
-# marked not to run the tests though as error messages will only refer to anyio
+# `get_cancelled_exc_class` will trigger errors even if anyio isn't imported, out of
+# an abundance of caution. But `anyio.get_cancelled_exc_class` will not
+# NOTRIO # anyio-specific check, see above
+# NOASYNCIO # anyio-specific check, see above
+# BASE_LIBRARY anyio
 from typing import Any
 
 import anyio

--- a/tests/eval_files/async118.py
+++ b/tests/eval_files/async118.py
@@ -1,5 +1,5 @@
 # `get_cancelled_exc_class` will trigger errors even if anyio isn't imported, out of
-# an abundance of caution. But `anyio.get_cancelled_exc_class` will not
+# an abundance of caution. But `anyio.get_cancelled_exc_class` will not.
 # NOTRIO # anyio-specific check, see above
 # NOASYNCIO # anyio-specific check, see above
 # BASE_LIBRARY anyio

--- a/tests/eval_files/async22x.py
+++ b/tests/eval_files/async22x.py
@@ -1,6 +1,6 @@
 # type: ignore
 # ARG --enable=ASYNC220,ASYNC221,ASYNC222
-# NOASYNCIO
+# NOASYNCIO - specifies error message differently
 
 
 async def foo():

--- a/tests/eval_files/async22x_asyncio.py
+++ b/tests/eval_files/async22x_asyncio.py
@@ -1,0 +1,80 @@
+# type: ignore
+# ARG --enable=ASYNC220,ASYNC221,ASYNC222
+# NOANYIO
+# NOTRIO
+# BASE_LIBRARY asyncio
+
+# same content as async22x.py, but different error message
+
+
+async def foo():
+    await async_fun(
+        subprocess.getoutput()  # ASYNC221_asyncio: 8, 'subprocess.getoutput'
+    )
+    subprocess.Popen()  # ASYNC220_asyncio: 4, 'subprocess.Popen'
+    os.system()  # ASYNC221_asyncio: 4, 'os.system'
+
+    system()
+    os.system.anything()
+    os.anything()
+
+    subprocess.run()  # ASYNC221_asyncio: 4, 'subprocess.run'
+    subprocess.call()  # ASYNC221_asyncio: 4, 'subprocess.call'
+    subprocess.check_call()  # ASYNC221_asyncio: 4, 'subprocess.check_call'
+    subprocess.check_output()  # ASYNC221_asyncio: 4, 'subprocess.check_output'
+    subprocess.getoutput()  # ASYNC221_asyncio: 4, 'subprocess.getoutput'
+    subprocess.getstatusoutput()  # ASYNC221_asyncio: 4, 'subprocess.getstatusoutput'
+
+    await async_fun(
+        subprocess.getoutput()  # ASYNC221_asyncio: 8, 'subprocess.getoutput'
+    )
+
+    subprocess.anything()
+    subprocess.foo()
+    subprocess.bar.foo()
+    subprocess()
+
+    os.posix_spawn()  # ASYNC221_asyncio: 4, 'os.posix_spawn'
+    os.posix_spawnp()  # ASYNC221_asyncio: 4, 'os.posix_spawnp'
+
+    os.spawn()
+    os.spawn
+    os.spawnllll()
+
+    os.spawnl()  # ASYNC221_asyncio: 4,   'os.spawnl'
+    os.spawnle()  # ASYNC221_asyncio: 4,  'os.spawnle'
+    os.spawnlp()  # ASYNC221_asyncio: 4,  'os.spawnlp'
+    os.spawnlpe()  # ASYNC221_asyncio: 4, 'os.spawnlpe'
+    os.spawnv()  # ASYNC221_asyncio: 4,   'os.spawnv'
+    os.spawnve()  # ASYNC221_asyncio: 4,  'os.spawnve'
+    os.spawnvp()  # ASYNC221_asyncio: 4,  'os.spawnvp'
+    os.spawnvpe()  # ASYNC221_asyncio: 4, 'os.spawnvpe'
+
+    # if mode is given, and is not os.P_WAIT: ASYNC220
+    os.spawnl(os.P_NOWAIT)  # ASYNC220_asyncio: 4,   'os.spawnl'
+    os.spawnl(P_NOWAIT)  # ASYNC220_asyncio: 4,   'os.spawnl'
+    os.spawnl(mode=os.P_NOWAIT)  # ASYNC220_asyncio: 4,   'os.spawnl'
+    os.spawnl(mode=P_NOWAIT)  # ASYNC220_asyncio: 4,   'os.spawnl'
+
+    # if it is P_WAIT, ASYNC221
+    os.spawnl(os.P_WAIT)  # ASYNC221_asyncio: 4,   'os.spawnl'
+    os.spawnl(P_WAIT)  # ASYNC221_asyncio: 4,   'os.spawnl'
+    os.spawnl(mode=os.P_WAIT)  # ASYNC221_asyncio: 4,   'os.spawnl'
+    os.spawnl(mode=P_WAIT)  # ASYNC221_asyncio: 4,   'os.spawnl'
+    # treating this as 221 to simplify code, and see no real reason not to
+    os.spawnl(foo.P_WAIT)  # ASYNC221_asyncio: 4,   'os.spawnl'
+
+    # other weird cases: ASYNC220
+    os.spawnl(0)  # ASYNC220_asyncio: 4,   'os.spawnl'
+    os.spawnl(1)  # ASYNC220_asyncio: 4,   'os.spawnl'
+    os.spawnl(foo())  # ASYNC220_asyncio: 4,   'os.spawnl'
+
+    # ASYNC222
+    os.wait()  # ASYNC222_asyncio: 4, 'os.wait'
+    os.wait3()  # ASYNC222_asyncio: 4, 'os.wait3'
+    os.wait4()  # ASYNC222_asyncio: 4, 'os.wait4'
+    os.waitid()  # ASYNC222_asyncio: 4, 'os.waitid'
+    os.waitpid()  # ASYNC222_asyncio: 4, 'os.waitpid'
+
+    os.waitpi()
+    os.waiti()

--- a/tests/eval_files/async232.py
+++ b/tests/eval_files/async232.py
@@ -14,7 +14,7 @@ async def file_text(f: io.TextIOWrapper):
     # there might be non-sync calls on TextIOWrappers? - but it will currently trigger
     # on all calls
     f.anything()  # ASYNC232: 4, 'anything', 'f', "trio"
-    f.aoeuaoeuoaeuaoeuaoeu()  # ASYNC232_asyncio: 4, 'aoeuaoeuaoeuaoeuaoeu', 'f'
+    f.aoeuaoeuaoeuaoeu()  # ASYNC232: 4, 'aoeuaoeuaoeuaoeu', 'f', "trio"
 
 
 # Test different file types for the type tracker
@@ -42,7 +42,7 @@ async def file_binary_read_(f: BufferedReader):
 
 
 async def file_binary_write_(f: BufferedWriter):
-    f.write()  # ASYNC232: 4, 'read', 'f', "trio"
+    f.read()  # ASYNC232: 4, 'read', 'f', "trio"
 
 
 async def file_binary_readwrite_(f: BufferedRandom):

--- a/tests/eval_files/async232.py
+++ b/tests/eval_files/async232.py
@@ -14,6 +14,11 @@ async def file_text(f: io.TextIOWrapper):
     # there might be non-sync calls on TextIOWrappers? - but it will currently trigger
     # on all calls
     f.anything()  # ASYNC232: 4, 'anything', 'f', "trio"
+    f.aoeuaoeuoaeuaoeuaoeu()  # ASYNC232_asyncio: 4, 'aoeuaoeuaoeuaoeuaoeu', 'f'
+
+
+# Test different file types for the type tracker
+# We use f.read() in all of them for simplicity, but any method call would trigger the same error
 
 
 async def file_binary_read(f: io.BufferedReader):
@@ -37,7 +42,7 @@ async def file_binary_read_(f: BufferedReader):
 
 
 async def file_binary_write_(f: BufferedWriter):
-    f.read()  # ASYNC232: 4, 'read', 'f', "trio"
+    f.write()  # ASYNC232: 4, 'read', 'f', "trio"
 
 
 async def file_binary_readwrite_(f: BufferedRandom):

--- a/tests/eval_files/async232_asyncio.py
+++ b/tests/eval_files/async232_asyncio.py
@@ -15,7 +15,7 @@ async def file_text(f: io.TextIOWrapper):
     # there might be non-sync calls on TextIOWrappers? - but it will currently trigger
     # on all calls
     f.anything()  # ASYNC232_asyncio: 4, 'anything', 'f'
-    f.aoeuaoeuoaeuaoeuaoeu()  # ASYNC232_asyncio: 4, 'aoeuaoeuaoeuaoeuaoeu', 'f'
+    f.aoeuaoeuaoeuaoeuaoeu()  # ASYNC232_asyncio: 4, 'aoeuaoeuaoeuaoeuaoeu', 'f'
 
 
 # Test different file types for the type tracker

--- a/tests/eval_files/async232_asyncio.py
+++ b/tests/eval_files/async232_asyncio.py
@@ -15,6 +15,11 @@ async def file_text(f: io.TextIOWrapper):
     # there might be non-sync calls on TextIOWrappers? - but it will currently trigger
     # on all calls
     f.anything()  # ASYNC232_asyncio: 4, 'anything', 'f'
+    f.aoeuaoeuoaeuaoeuaoeu()  # ASYNC232_asyncio: 4, 'aoeuaoeuaoeuaoeuaoeu', 'f'
+
+
+# Test different file types for the type tracker
+# We use f.read() in all of them for simplicity, but any method call would trigger the same error
 
 
 async def file_binary_read(f: io.BufferedReader):

--- a/tests/eval_files/async232_asyncio.py
+++ b/tests/eval_files/async232_asyncio.py
@@ -1,5 +1,6 @@
 # type: ignore
-# NOASYNCIO # see async232_asyncio.py
+# NOTRIO # see async232.py
+# NOANYIO # see async232.py
 import io
 from io import BufferedRandom, BufferedReader, BufferedWriter, TextIOWrapper
 from typing import Any, Optional
@@ -8,56 +9,56 @@ blah: Any = None
 
 
 async def file_text(f: io.TextIOWrapper):
-    f.read()  # ASYNC232: 4, 'read', 'f', "trio"
-    f.readlines()  # ASYNC232: 4, 'readlines', 'f', "trio"
+    f.read()  # ASYNC232_asyncio: 4, 'read', 'f'
+    f.readlines()  # ASYNC232_asyncio: 4, 'readlines', 'f'
 
     # there might be non-sync calls on TextIOWrappers? - but it will currently trigger
     # on all calls
-    f.anything()  # ASYNC232: 4, 'anything', 'f', "trio"
+    f.anything()  # ASYNC232_asyncio: 4, 'anything', 'f'
 
 
 async def file_binary_read(f: io.BufferedReader):
-    f.read()  # ASYNC232: 4, 'read', 'f', "trio"
+    f.read()  # ASYNC232_asyncio: 4, 'read', 'f'
 
 
 async def file_binary_write(f: io.BufferedWriter):
-    f.read()  # ASYNC232: 4, 'read', 'f', "trio"
+    f.read()  # ASYNC232_asyncio: 4, 'read', 'f'
 
 
 async def file_binary_readwrite(f: io.BufferedRandom):
-    f.read()  # ASYNC232: 4, 'read', 'f', "trio"
+    f.read()  # ASYNC232_asyncio: 4, 'read', 'f'
 
 
 async def file_text_(f: TextIOWrapper):
-    f.read()  # ASYNC232: 4, 'read', 'f', "trio"
+    f.read()  # ASYNC232_asyncio: 4, 'read', 'f'
 
 
 async def file_binary_read_(f: BufferedReader):
-    f.read()  # ASYNC232: 4, 'read', 'f', "trio"
+    f.read()  # ASYNC232_asyncio: 4, 'read', 'f'
 
 
 async def file_binary_write_(f: BufferedWriter):
-    f.read()  # ASYNC232: 4, 'read', 'f', "trio"
+    f.read()  # ASYNC232_asyncio: 4, 'read', 'f'
 
 
 async def file_binary_readwrite_(f: BufferedRandom):
-    f.read()  # ASYNC232: 4, 'read', 'f', "trio"
+    f.read()  # ASYNC232_asyncio: 4, 'read', 'f'
 
 
 async def file_text_3(f: TextIOWrapper = blah):
-    f.read()  # ASYNC232: 4, 'read', 'f', "trio"
+    f.read()  # ASYNC232_asyncio: 4, 'read', 'f'
 
 
 async def file_text_4(f: TextIOWrapper | None):
-    f.read()  # ASYNC232: 4, 'read', 'f', "trio"
+    f.read()  # ASYNC232_asyncio: 4, 'read', 'f'
     if f:
-        f.read()  # ASYNC232: 8, 'read', 'f', "trio"
+        f.read()  # ASYNC232_asyncio: 8, 'read', 'f'
 
 
 async def file_text_4_left(f: None | TextIOWrapper):
-    f.read()  # ASYNC232: 4, 'read', 'f', "trio"
+    f.read()  # ASYNC232_asyncio: 4, 'read', 'f'
     if f:
-        f.read()  # ASYNC232: 8, 'read', 'f', "trio"
+        f.read()  # ASYNC232_asyncio: 8, 'read', 'f'
 
 
 # not handled
@@ -71,25 +72,25 @@ async def file_text_4_non_none(f: TextIOWrapper | int):
 
 
 async def file_text_5(f: TextIOWrapper | None = None):
-    f.read()  # ASYNC232: 4, 'read', 'f', "trio"
+    f.read()  # ASYNC232_asyncio: 4, 'read', 'f'
     if f:
-        f.read()  # ASYNC232: 8, 'read', 'f', "trio"
+        f.read()  # ASYNC232_asyncio: 8, 'read', 'f'
 
 
 async def file_text_6(f: Optional[TextIOWrapper] = None):
-    f.read()  # ASYNC232: 4, 'read', 'f', "trio"
+    f.read()  # ASYNC232_asyncio: 4, 'read', 'f'
     if f:
-        f.read()  # ASYNC232: 8, 'read', 'f', "trio"
+        f.read()  # ASYNC232_asyncio: 8, 'read', 'f'
 
 
 # posonly
 async def file_text_7(f: TextIOWrapper = blah, /):
-    f.read()  # ASYNC232: 4, 'read', 'f', "trio"
+    f.read()  # ASYNC232_asyncio: 4, 'read', 'f'
 
 
 # keyword-only
 async def file_text_8(*, f: TextIOWrapper = blah):
-    f.read()  # ASYNC232: 4, 'read', 'f', "trio"
+    f.read()  # ASYNC232_asyncio: 4, 'read', 'f'
 
 
 async def file_text_9(lf: list[TextIOWrapper]):
@@ -109,7 +110,7 @@ async def open_file_2():
 
 async def open_file_3():
     with open("") as f:
-        f.read()  # ASYNC232: 8, 'read', 'f', "trio"
+        f.read()  # ASYNC232_asyncio: 8, 'read', 'f'
 
 
 async def open_file_4():
@@ -118,14 +119,14 @@ async def open_file_4():
 
 async def open_file_5():
     f = open("")
-    f.read()  # ASYNC232: 4, 'read', 'f', "trio"
+    f.read()  # ASYNC232_asyncio: 4, 'read', 'f'
 
 
 async def open_file_6():
     ff = open("")
     f = ff
-    f.read()  # ASYNC232: 4, 'read', 'f', "trio"
-    ff.read()  # ASYNC232: 4, 'read', 'ff', "trio"
+    f.read()  # ASYNC232_asyncio: 4, 'read', 'f'
+    ff.read()  # ASYNC232_asyncio: 4, 'read', 'ff'
 
 
 async def noerror():
@@ -135,19 +136,19 @@ async def noerror():
 
 def sync_fun(f: TextIOWrapper):
     async def async_fun():
-        f.read()  # ASYNC232: 8, 'read', 'f', "trio"
+        f.read()  # ASYNC232_asyncio: 8, 'read', 'f'
 
 
 def sync_fun_2():
     f = open("")
 
     async def async_fun():
-        f.read()  # ASYNC232: 8, 'read', 'f', "trio"
+        f.read()  # ASYNC232_asyncio: 8, 'read', 'f'
 
 
 async def type_assign():
     f: TextIOWrapper = ...
-    f.read()  # ASYNC232: 4, 'read', 'f', "trio"
+    f.read()  # ASYNC232_asyncio: 4, 'read', 'f'
 
 
 # define global variables
@@ -165,16 +166,16 @@ async def async_wrapper(f: TextIOWrapper):
 
         f.read()
 
-    f.read()  # ASYNC232: 4, 'read', 'f', "trio"
+    f.read()  # ASYNC232_asyncio: 4, 'read', 'f'
     lambda f: f.read()
-    f.read()  # ASYNC232: 4, 'read', 'f', "trio"
-    f.read()  # ASYNC232: 4, 'read', 'f', "trio"
+    f.read()  # ASYNC232_asyncio: 4, 'read', 'f'
+    f.read()  # ASYNC232_asyncio: 4, 'read', 'f'
 
 
 # and show that they're still marked as TextIOWrappers
 async def global_vars():
-    f.read()  # ASYNC232: 4, 'read', 'f', "trio"
-    g.read()  # ASYNC232: 4, 'read', 'g', "trio"
+    f.read()  # ASYNC232_asyncio: 4, 'read', 'f'
+    g.read()  # ASYNC232_asyncio: 4, 'read', 'g'
 
 
 # If the type is explicitly overridden, it will not error
@@ -182,11 +183,11 @@ async def overridden_type(f: TextIOWrapper):
     f: int = 7
     f.read()
     f: TextIOWrapper = ...
-    f.read()  # ASYNC232: 4, 'read', 'f', "trio"
+    f.read()  # ASYNC232_asyncio: 4, 'read', 'f'
     f: int = 7
     f.read()
     f: TextIOWrapper = ...
-    f.read()  # ASYNC232: 4, 'read', 'f', "trio"
+    f.read()  # ASYNC232_asyncio: 4, 'read', 'f'
 
 
 # ***** Known unhandled cases *****
@@ -196,9 +197,9 @@ async def overridden_type(f: TextIOWrapper):
 async def implicit_overridden_type():
     f: TextIOWrapper = ...
     f = arbitrary_function()
-    f.read()  # ASYNC232: 4, 'read', 'f', "trio"
+    f.read()  # ASYNC232_asyncio: 4, 'read', 'f'
     f = 7
-    f.read()  # ASYNC232: 4, 'read', 'f', "trio"
+    f.read()  # ASYNC232_asyncio: 4, 'read', 'f'
 
 
 # Tuple assignments are completely ignored
@@ -224,13 +225,13 @@ async def attribute_access_on_object():
 # to the type
 async def type_restricting_1(f: Optional[TextIOWrapper] = None):
     if f is None:
-        f.read()  # ASYNC232: 8, 'read', 'f', "trio"
+        f.read()  # ASYNC232_asyncio: 8, 'read', 'f'
 
 
 async def type_restricting_2(f: Optional[TextIOWrapper] = None):
     if isinstance(f, TextIOWrapper):
         return
-    f.read()  # ASYNC232: 4, 'read', 'f', "trio"
+    f.read()  # ASYNC232_asyncio: 4, 'read', 'f'
 
 
 # Classes are not supported, partly due to not handling attributes at all,

--- a/tests/eval_files/async23x.py
+++ b/tests/eval_files/async23x.py
@@ -1,6 +1,6 @@
 # type: ignore
 # ARG --enable=ASYNC230,ASYNC231
-# NOASYNCIO
+# NOASYNCIO # see async23x_asyncio.py
 import io
 import os
 

--- a/tests/eval_files/async23x_asyncio.py
+++ b/tests/eval_files/async23x_asyncio.py
@@ -17,7 +17,9 @@ async def foo():
     # sync call is awaited, so it can't be sync
     await open("")
 
-    # asyncio.wrap_file does not exist
+    # asyncio.wrap_file does not exist, so check that it doesn't trigger the
+    # protection that e.g. `trio.wrap_file` would give.
+    # In theory we could support detecting equivalent `wrap_file`s from other libraries
     await asyncio.wrap_file(open(""))  # ASYNC230_asyncio: 28, 'open'
     await asyncio.wrap_file(os.fdopen(0))  # ASYNC231_asyncio: 28, 'os.fdopen'
 

--- a/tests/eval_files/async23x_asyncio.py
+++ b/tests/eval_files/async23x_asyncio.py
@@ -1,0 +1,46 @@
+# type: ignore
+# ARG --enable=ASYNC230,ASYNC231
+# NOTRIO # see async23x.py
+# NOANYIO # see async23x.py
+# BASE_LIBRARY asyncio
+import io
+import os
+
+import asyncio
+
+
+async def foo():
+    open("")  # ASYNC230_asyncio: 4, 'open'
+    io.open_code("")  # ASYNC230_asyncio: 4, 'io.open_code'
+    os.fdopen(0)  # ASYNC231_asyncio: 4, 'os.fdopen'
+
+    # sync call is awaited, so it can't be sync
+    await open("")
+
+    # asyncio.wrap_file does not exist
+    await asyncio.wrap_file(open(""))  # ASYNC230_asyncio: 28, 'open'
+    await asyncio.wrap_file(os.fdopen(0))  # ASYNC231_asyncio: 28, 'os.fdopen'
+
+    # with uses the same code & logic
+    with os.fdopen(0):  # ASYNC231_asyncio: 9, 'os.fdopen'
+        ...
+    with open(""):  # ASYNC230_asyncio: 9, 'open'
+        ...
+    with open("") as f:  # ASYNC230_asyncio: 9, 'open'
+        ...
+    with foo(), open(""):  # ASYNC230_asyncio: 16, 'open'
+        ...
+    async with open(""):  # ASYNC230_asyncio: 15, 'open'
+        ...
+    async with asyncio.wrap_file(open("")):  # ASYNC230_asyncio: 33, 'open'
+        ...
+
+    # test io.open
+    # pyupgrade removes the unnecessary `io.`
+    # https://github.com/asottile/pyupgrade#open-alias
+    # and afaict neither respects fmt:off nor #noqa - so I don't know how to test it
+    open("")  # ASYNC230_asyncio: 4, 'open'
+
+
+def foo_sync():
+    open("")

--- a/tests/eval_files/no_library.py
+++ b/tests/eval_files/no_library.py
@@ -1,6 +1,5 @@
 # type: ignore
 # ARG --enable=ASYNC220
-# NOANYIO
 # NOASYNCIO
 async def foo():
     subprocess.Popen()  # ASYNC220: 4, 'subprocess.Popen', "trio"

--- a/tests/eval_files/noqa.py
+++ b/tests/eval_files/noqa.py
@@ -1,6 +1,5 @@
 # AUTOFIX
-# NOANYIO # TODO
-# NOASYNCIO
+# NOASYNCIO - does not trigger on ASYNC100
 # ARG --enable=ASYNC100,ASYNC911
 from typing import Any
 

--- a/tests/eval_files/noqa_testing.py
+++ b/tests/eval_files/noqa_testing.py
@@ -1,5 +1,4 @@
 # AUTOFIX
-# NOANYIO # TODO
 # ARG --enable=ASYNC911
 import trio
 

--- a/tests/eval_files/trio_anyio.py
+++ b/tests/eval_files/trio_anyio.py
@@ -1,7 +1,6 @@
 # type: ignore
 # ARG --enable=ASYNC220
 # NOANYIO
-# NOASYNCIO  # TODO
 import trio  # isort: skip
 import anyio  # isort: skip
 

--- a/tests/test_flake8_async.py
+++ b/tests/test_flake8_async.py
@@ -216,12 +216,11 @@ def find_magic_markers(
     return found_markers
 
 
-# This could be optimized not to reopen+reread+reparse the same file over and over
-# when testing the same file
-@pytest.mark.parametrize(("test", "path"), test_files, ids=[f[0] for f in test_files])
+# Caching test file content makes ~0 difference to runtime
+@pytest.mark.parametrize("noqa", [False, True], ids=["normal", "noqa"])
 @pytest.mark.parametrize("autofix", [False, True], ids=["noautofix", "autofix"])
 @pytest.mark.parametrize("library", ["trio", "anyio", "asyncio"])
-@pytest.mark.parametrize("noqa", [False, True], ids=["normal", "noqa"])
+@pytest.mark.parametrize(("test", "path"), test_files, ids=[f[0] for f in test_files])
 def test_eval(
     test: str,
     path: Path,
@@ -232,6 +231,7 @@ def test_eval(
 ):
     content = path.read_text()
     magic_markers = find_magic_markers(content)
+
     # if autofixing, columns may get messed up
     ignore_column = autofix
     only_check_not_crash = False

--- a/tests/test_flake8_async.py
+++ b/tests/test_flake8_async.py
@@ -258,7 +258,7 @@ def test_eval(
         content = re.sub(r"#[\s]*(error|ASYNC\d\d\d):.*", "# noqa", content)
 
     expected, parsed_args, enable = _parse_eval_file(
-        test, content, only_parse_args=only_check_not_crash
+        test, content, only_check_not_crash=only_check_not_crash
     )
     if library != "trio":
         parsed_args.insert(0, f"--{library}")
@@ -286,12 +286,12 @@ def test_eval(
         return
 
     # Check that error messages refer to current library, or to no library.
-    # 103_[BOTH/ALL]_IMPORTED will contain messages that refer to anyio regardless of
-    # current library
-    # 23X_asyncio messages does not mention asyncio
     if test not in (
+        # 103_[BOTH/ALL]_IMPORTED will contain messages that refer to anyio regardless of
+        # current library
         "ASYNC103_BOTH_IMPORTED",
         "ASYNC103_ALL_IMPORTED",
+        # 23X_asyncio messages does not mention asyncio
         "ASYNC23X_ASYNCIO",
     ):
         for error in errors:
@@ -338,7 +338,7 @@ def test_autofix(test: str):
 
 
 def _parse_eval_file(
-    test: str, content: str, only_parse_args: bool = False
+    test: str, content: str, only_check_not_crash: bool = False
 ) -> tuple[list[Error], list[str], str]:
     # version check
     check_version(test)
@@ -406,7 +406,7 @@ def _parse_eval_file(
 
             if err_code == "error":
                 err_code = test
-            if only_parse_args and err_code + alt_code not in ERROR_CODES:
+            if only_check_not_crash and err_code + alt_code not in ERROR_CODES:
                 continue
             error_class = ERROR_CODES[err_code + alt_code]
             message = error_class.error_codes[err_code + alt_code]


### PR DESCRIPTION
* Add asyncio-specific error messages for 2xx.
* Add check in tests to detect if [library]_NO_ERROR should be used, add it to several checks.
* Specify why NO_[library] and [library]_NO_ERROR is specified in a lot of eval files.