### PR TITLE
Add new check ASYNC251 for time.sleep()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 *[CalVer, YY.month.patch](https://calver.org/)*
 
+## 24.3.3
+- Add ASYNC251: `time.sleep()` in async method.
+
 ## 24.3.2
 - Add ASYNC250: blocking sync call `input()` in async method.
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ Note: 22X, 23X and 24X has not had asyncio-specific suggestions written.
 - **ASYNC231**: Sync IO call in async function, use `[trio/anyio].wrap_file(...)`. `asyncio` users need to use a library such as [aiofiles](https://pypi.org/project/aiofiles/), or switch to [anyio](https://github.com/agronholm/anyio).
 - **ASYNC232**: Blocking sync call on file object, wrap the file object in `[trio/anyio].wrap_file()` to get an async file object.
 - **ASYNC240**: Avoid using `os.path` in async functions, prefer using `[trio/anyio].Path` objects. `asyncio` users should consider [aiopath](https://pypi.org/project/aiopath) or [anyio](https://github.com/agronholm/anyio).
-- **ASYNC250**: Builtin `input()` should not be called from async function.
+- **ASYNC250**: Builtin `input()` should not be called from async function. Wrap in `[trio/anyio].to_thread.run_sync()` or `asyncio.loop.run_in_executor()`.
+- **ASYNC251**: `time.sleep(...)` should not be called from async function. Use `[trio/anyio/asyncio].sleep(...)`.
 
 ### Warnings disabled by default
 - **ASYNC900**: Async generator without `@asynccontextmanager` not allowed. You might want to enable this on a codebase since async generators are inherently unsafe and cleanup logic might not be performed. See https://github.com/python-trio/flake8-async/issues/211 and https://discuss.python.org/t/using-exceptiongroup-at-anthropic-experience-report/20888/6 for discussion.

--- a/flake8_async/visitors/__init__.py
+++ b/flake8_async/visitors/__init__.py
@@ -25,7 +25,7 @@ default_disabled_error_codes: list[str] = []
 utility_visitors: set[type[Flake8AsyncVisitor]] = set()
 utility_visitors_cst: set[type[Flake8AsyncVisitor_cst]] = set()
 
-# Import all visitors so their decorators run, filling the above containers
+# Import all files with visitors so their decorators run, filling the above containers
 # This has to be done at the end to avoid circular imports
 from . import (
     visitor2xx,

--- a/tests/eval_files/async251.py
+++ b/tests/eval_files/async251.py
@@ -1,0 +1,13 @@
+# NOAUTOFIX
+
+import time
+from time import sleep
+
+
+async def foo():
+    time.sleep(5) if 5 else None  # ASYNC251: 8, "trio"
+    time.sleep(5)  # ASYNC251: 4, "trio"
+
+    # Not handled due to difficulty tracking imports and not wanting to trigger
+    # false positives. But could definitely be handled by ruff et al.
+    sleep(5)

--- a/tests/eval_files/async251_multi_library.py
+++ b/tests/eval_files/async251_multi_library.py
@@ -1,0 +1,9 @@
+# BASE_LIBRARY trio
+# NOASYNCIO # tests asyncio without replacing for it
+import trio
+import time
+import asyncio
+
+
+async def foo():
+    time.sleep(5)  # ASYNC251: 4, "[trio/asyncio]"


### PR DESCRIPTION
As noted in https://github.com/astral-sh/ruff/pull/10416 old-flake8-async checked for `time.sleep()`, but none do currently, so I quickly added it.