### PR TITLE
async110 now also warns if looping .lowlevel.checkpoint()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 *[CalVer, YY.month.patch](https://calver.org/)*
 
+## 24.3.4
+- ASYNC110 (don't loop sleep) now also warns if looping `[trio/anyio].lowlevel.checkpoint()`
+
 ## 24.3.3
 - Add ASYNC251: `time.sleep()` in async method.
 

--- a/flake8_async/__init__.py
+++ b/flake8_async/__init__.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
 
 
 # CalVer: YY.month.patch, e.g. first release of July 2022 == "22.7.1"
-__version__ = "24.3.3"
+__version__ = "24.3.4"
 
 
 # taken from https://github.com/Zac-HD/shed

--- a/tests/eval_files/async110.py
+++ b/tests/eval_files/async110.py
@@ -69,3 +69,8 @@ async def foo():
 
     while await trio.sleep():
         ...
+
+    # also error when looping .lowlevel.checkpoint, which is equivalent to .sleep(0)
+    # see https://github.com/python-trio/flake8-async/issues/201
+    while ...:  # ASYNC110: 4, "trio"
+        await trio.lowlevel.checkpoint()


### PR DESCRIPTION
fixes #201