### PR TITLE
ASYNC102 no longer raises warning for calls to `.aclose()` on objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 *[CalVer, YY.month.patch](https://calver.org/)*
 
+## 24.3.4
+- ASYNC102 (no await inside finally or critical except) no longer raises warnings for calls to `aclose()` on objects. See https://github.com/python-trio/flake8-async/issues/156
+
 ## 24.3.3
 - Add ASYNC251: `time.sleep()` in async method.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 *[CalVer, YY.month.patch](https://calver.org/)*
 
-## 24.3.4
+## 24.3.5
 - ASYNC102 (no await inside finally or critical except) no longer raises warnings for calls to `aclose()` on objects. See https://github.com/python-trio/flake8-async/issues/156
 
 ## 24.3.3

--- a/flake8_async/__init__.py
+++ b/flake8_async/__init__.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
 
 
 # CalVer: YY.month.patch, e.g. first release of July 2022 == "22.7.1"
-__version__ = "24.3.3"
+__version__ = "24.3.4"
 
 
 # taken from https://github.com/Zac-HD/shed

--- a/flake8_async/visitors/visitor102.py
+++ b/flake8_async/visitors/visitor102.py
@@ -55,6 +55,15 @@ class Visitor102(Flake8AsyncVisitor):
     # if we're inside a finally, and we're not inside a scope that doesn't have
     # both a timeout and shield
     def visit_Await(self, node: ast.Await | ast.AsyncFor | ast.AsyncWith):
+        if (
+            self._critical_scope is not None
+            and self._critical_scope.name == "try/finally"
+            and isinstance(node, ast.Await)
+            and isinstance(node.value, ast.Call)
+            and isinstance(node.value.func, ast.Attribute)
+            and node.value.func.attr == "aclose"
+        ):
+            return
         if self._critical_scope is not None and not any(
             cm.has_timeout and cm.shielded for cm in self._trio_context_managers
         ):

--- a/tests/eval_files/async102.py
+++ b/tests/eval_files/async102.py
@@ -252,3 +252,16 @@ async def foo_nested_excepts():
             await foo()
         await foo()
     await foo()
+
+
+# double check that this works nested inside an async for
+async def foo_nested_async_for():
+
+    async for i in trio.bypasslinters:
+        try:
+            ...
+        except BaseException:
+            async for (  # error: 12, Statement("BaseException", lineno-1)
+                j
+            ) in trio.bypasslinters:
+                ...

--- a/tests/eval_files/async102_aclose.py
+++ b/tests/eval_files/async102_aclose.py
@@ -1,0 +1,18 @@
+# type: ignore
+# exclude finally: await x.aclose() from async102
+
+
+async def foo():
+    # no type tracking in this check, we allow any call that looks like
+    # `await [...].aclose()`
+    x = None
+
+    try:
+        ...
+    except BaseException:
+        # still not allowed in BaseException
+        await x.aclose()  # ASYNC102: 8, Statement("BaseException", lineno-2)
+    finally:
+        # but these will no longer raise any errors
+        await x.aclose()
+        await x.y.aclose()

--- a/tests/eval_files/async102_aclose.py
+++ b/tests/eval_files/async102_aclose.py
@@ -1,5 +1,10 @@
 # type: ignore
-# exclude finally: await x.aclose() from async102
+
+# exclude finally: await x.aclose() from async102, with trio/anyio
+# ANYIO_NO_ERROR
+# TRIO_NO_ERROR
+# See also async102_aclose_args.py - which makes sure trio/anyio raises errors if there
+# are arguments to aclose().
 
 
 async def foo():
@@ -10,9 +15,8 @@ async def foo():
     try:
         ...
     except BaseException:
-        # still not allowed in BaseException
-        await x.aclose()  # ASYNC102: 8, Statement("BaseException", lineno-2)
+        await x.aclose()  # ASYNC102: 8, Statement("BaseException", lineno-1)
+        await x.y.aclose()  # ASYNC102: 8, Statement("BaseException", lineno-2)
     finally:
-        # but these will no longer raise any errors
-        await x.aclose()
-        await x.y.aclose()
+        await x.aclose()  # ASYNC102: 8, Statement("try/finally", lineno-6)
+        await x.y.aclose()  # ASYNC102: 8, Statement("try/finally", lineno-7)

--- a/tests/eval_files/async102_aclose_args.py
+++ b/tests/eval_files/async102_aclose_args.py
@@ -1,0 +1,24 @@
+# type: ignore
+
+# trio/anyio should still raise errors if there's args
+# asyncio will always raise errors
+
+# See also async102_aclose.py, which checks that trio/anyio marks arg-less aclose() as safe
+
+
+async def foo():
+    # no type tracking in this check
+    x = None
+
+    try:
+        ...
+    except BaseException:
+        await x.aclose(foo)  # ASYNC102: 8, Statement("BaseException", lineno-1)
+        await x.aclose(bar=foo)  # ASYNC102: 8, Statement("BaseException", lineno-2)
+        await x.aclose(*foo)  # ASYNC102: 8, Statement("BaseException", lineno-3)
+        await x.aclose(None)  # ASYNC102: 8, Statement("BaseException", lineno-4)
+    finally:
+        await x.aclose(foo)  # ASYNC102: 8, Statement("try/finally", lineno-8)
+        await x.aclose(bar=foo)  # ASYNC102: 8, Statement("try/finally", lineno-9)
+        await x.aclose(*foo)  # ASYNC102: 8, Statement("try/finally", lineno-10)
+        await x.aclose(None)  # ASYNC102: 8, Statement("try/finally", lineno-11)

--- a/tests/test_messages_documented.py
+++ b/tests/test_messages_documented.py
@@ -44,7 +44,9 @@ def test_messages_documented():
         if not file_path.is_file():
             continue
 
-        if m := re.search(r"async\d\d\d", str(file_path)):
+        # only look in the stem (final part of the path), so as not to get tripped
+        # up by [git worktree] directories with an exception code in the name
+        if m := re.search(r"^async\d\d\d", str(file_path.stem)):
             documented_errors["eval_files"].add(m.group().upper())
 
         with open(file_path) as file:


### PR DESCRIPTION
See #156 

I'm not sure if #156 also covers more general discussion on if/how to overhaul async102 and should remain open after this is merged.