### PR TITLE
fix internal error in visitor91x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 *[CalVer, YY.month.patch](https://calver.org/)*
 
+## 24.4.1
+- ASYNC91X fix internal error caused by multiple `try/except` incorrectly sharing state.
+
 ## 24.3.5
 - ASYNC102 (no await inside finally or critical except) no longer raises warnings for calls to `aclose()` on objects in trio/anyio code. See https://github.com/python-trio/flake8-async/issues/156
 

--- a/flake8_async/__init__.py
+++ b/flake8_async/__init__.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
 
 
 # CalVer: YY.month.patch, e.g. first release of July 2022 == "22.7.1"
-__version__ = "24.3.5"
+__version__ = "24.4.1"
 
 
 # taken from https://github.com/Zac-HD/shed

--- a/flake8_async/visitors/visitor91x.py
+++ b/flake8_async/visitors/visitor91x.py
@@ -454,7 +454,7 @@ class Visitor91X(Flake8AsyncVisitor_cst, CommonVisitors):
     def visit_Try(self, node: cst.Try):
         if not self.async_function:
             return
-        self.save_state(node, "try_state")
+        self.save_state(node, "try_state", copy=True)
         # except & finally guaranteed to enter with checkpoint if checkpointed
         # before try and no yield in try body.
         self.try_state.body_uncheckpointed_statements = (
@@ -596,6 +596,8 @@ class Visitor91X(Flake8AsyncVisitor_cst, CommonVisitors):
         self.save_state(
             node,
             "uncheckpointed_statements",
+            # reference is overwritten below so don't need to copy
+            copy=False,
         )
 
         # inject an artificial uncheckpointed statement that won't raise an error,

--- a/tests/autofix_files/async910.py
+++ b/tests/autofix_files/async910.py
@@ -601,3 +601,16 @@ async def await_in_gen_target():
 async def await_everywhere_except_gen_target():  # error: 0, "exit", Statement("function definition", lineno)
     (await x async for x in bar())
     await trio.lowlevel.checkpoint()
+
+
+# Issue #226
+async def fn_226():  # error: 0, "exit", Statement("function definition", lineno)
+    try:
+        while foo():
+            try:
+                await trio.sleep(1)
+            except Exception:
+                pass
+    except Exception:
+        pass
+    await trio.lowlevel.checkpoint()

--- a/tests/autofix_files/async910.py.diff
+++ b/tests/autofix_files/async910.py.diff
@@ -205,8 +205,16 @@
 
 
  async def foo_comprehension_3():
-@@ x,3 x,4 @@
+@@ x,6 x,7 @@
 
  async def await_everywhere_except_gen_target():  # error: 0, "exit", Statement("function definition", lineno)
      (await x async for x in bar())
++    await trio.lowlevel.checkpoint()
+
+
+ # Issue #226
+@@ x,3 x,4 @@
+                 pass
+     except Exception:
+         pass
 +    await trio.lowlevel.checkpoint()

--- a/tests/eval_files/async900.py
+++ b/tests/eval_files/async900.py
@@ -1,5 +1,6 @@
 # type: ignore
 # ARG --no-checkpoint-warning-decorator=asynccontextmanager,other_context_manager
+import trio
 from contextlib import asynccontextmanager
 
 
@@ -54,3 +55,15 @@ async def this_is_not_an_async_generator():
 async def another_non_generator():
     def foo():
         yield
+
+
+# issue 226
+async def fn():
+    try:
+        while True:
+            try:
+                await trio.sleep(1)
+            except Exception:
+                pass
+    except Exception:
+        pass

--- a/tests/eval_files/async900.py
+++ b/tests/eval_files/async900.py
@@ -1,6 +1,5 @@
 # type: ignore
 # ARG --no-checkpoint-warning-decorator=asynccontextmanager,other_context_manager
-import trio
 from contextlib import asynccontextmanager
 
 
@@ -55,15 +54,3 @@ async def this_is_not_an_async_generator():
 async def another_non_generator():
     def foo():
         yield
-
-
-# issue 226
-async def fn():
-    try:
-        while True:
-            try:
-                await trio.sleep(1)
-            except Exception:
-                pass
-    except Exception:
-        pass

--- a/tests/eval_files/async910.py
+++ b/tests/eval_files/async910.py
@@ -572,3 +572,15 @@ async def await_in_gen_target():
 
 async def await_everywhere_except_gen_target():  # error: 0, "exit", Statement("function definition", lineno)
     (await x async for x in bar())
+
+
+# Issue #226
+async def fn_226():  # error: 0, "exit", Statement("function definition", lineno)
+    try:
+        while foo():
+            try:
+                await trio.sleep(1)
+            except Exception:
+                pass
+    except Exception:
+        pass

--- a/tests/test_flake8_async.py
+++ b/tests/test_flake8_async.py
@@ -416,6 +416,7 @@ def _parse_eval_file(
                 msg = f"Line {lineno}: Failed to format\n {message!r}\nwith\n{args}"
                 raise ParseError(msg) from e
 
+    assert enabled_codes, "no codes enabled. Fix file name or add `# ARGS --enable=...`"
     enabled_codes_list = enabled_codes.split(",")
     for code in enabled_codes_list:
         assert re.fullmatch(


### PR DESCRIPTION
fixes #226 
Underlying issue was different try/except's sharing the same reference to self.try_state, due to not passing `copy=True` to `save_state()`.

I went through the other calls to `save_state` in the same visitor and added an explicit `copy=False` to the only other one that didn't already specify it. It's possible `save_state()` shouldn't have a default at all, or default to `True` since the performance loss from some extra copying would probably be negligible.