### PR TITLE
add async119: yield in contextmanager in async generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 *[CalVer, YY.month.patch](https://calver.org/)*
 
-## 24.4.23
+## 24.4.2
 - Add ASYNC119: yield in contextmanager in async generator.
 
 ## 24.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 *[CalVer, YY.month.patch](https://calver.org/)*
 
+## 24.4.23
+- Add ASYNC119: yield in contextmanager in async generator.
 
 ## 24.4.1
 - ASYNC91X fix internal error caused by multiple `try/except` incorrectly sharing state.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ pip install flake8-async
 - **ASYNC115**: Replace `[trio/anyio].sleep(0)` with the more suggestive `[trio/anyio].lowlevel.checkpoint()`.
 - **ASYNC116**: `[trio/anyio].sleep()` with >24 hour interval should usually be `[trio/anyio].sleep_forever()`.
 - **ASYNC118**: Don't assign the value of `anyio.get_cancelled_exc_class()` to a variable, since that breaks linter checks and multi-backend programs.
+- **ASYNC119**: `yield` in context manager in async generator is unsafe, the cleanup may be delayed until `await` is no longer allowed. We strongly encourage you to read PEP-533 and use `async with aclosing(...)`, or better yet avoid async generators entirely (see ASYNC900) in favor of context managers which return an iterable channel/queue.
 
 ### Warnings for blocking sync calls in async functions
 Note: 22X, 23X and 24X has not had asyncio-specific suggestions written.

--- a/docs/rules.rst
+++ b/docs/rules.rst
@@ -45,10 +45,11 @@ Note: 22X, 23X and 24X has not had asyncio-specific suggestions written.
 - **ASYNC250**: Builtin ``input()`` should not be called from async function. Wrap in ``[trio/anyio].to_thread.run_sync()`` or ``asyncio.loop.run_in_executor()``.
 - **ASYNC251**: ``time.sleep(...)`` should not be called from async function. Use ``[trio/anyio/asyncio].sleep(...)``.
 
-.. _async900:
 
 Optional rules disabled by default
 ==================================
+
+.. _async900:
 
 - **ASYNC900**: Async generator without ``@asynccontextmanager`` not allowed. You might want to enable this on a codebase since async generators are inherently unsafe and cleanup logic might not be performed. See https://github.com/python-trio/flake8-async/issues/211 and https://discuss.python.org/t/using-exceptiongroup-at-anthropic-experience-report/20888/6 for discussion.
 - **ASYNC910**: Exit or ``return`` from async function with no guaranteed checkpoint or exception since function definition. You might want to enable this on a codebase to make it easier to reason about checkpoints, and make the logic of ASYNC911 correct.

--- a/docs/rules.rst
+++ b/docs/rules.rst
@@ -21,6 +21,9 @@ General rules
 - **ASYNC115**: Replace ``[trio/anyio].sleep(0)`` with the more suggestive ``[trio/anyio].lowlevel.checkpoint()``.
 - **ASYNC116**: ``[trio/anyio].sleep()`` with >24 hour interval should usually be ``[trio/anyio].sleep_forever()``.
 - **ASYNC118**: Don't assign the value of ``anyio.get_cancelled_exc_class()`` to a variable, since that breaks linter checks and multi-backend programs.
+- **ASYNC119**: ``yield`` in context manager in async generator is unsafe, the cleanup may be delayed until ``await`` is no longer allowed. We strongly encourage you to read `PEP 533 <https://peps.python.org/pep-0533/>`_ and use `async with aclosing(...) <https://docs.python.org/3/library/contextlib.html#contextlib.aclosing>`_, or better yet avoid async generators entirely (see :ref:`ASYNC900 <async900>` ) in favor of context managers which return an iterable `channel (trio) <https://trio.readthedocs.io/en/stable/reference-core.html#channels>`_, `stream (anyio) <https://anyio.readthedocs.io/en/stable/streams.html#streams>`_, or `queue (asyncio) <https://docs.python.org/3/library/asyncio-queue.html>`_.
+
+  .. TODO: use intersphinx(?) instead of having to specify full URL
 
 Blocking sync calls in async functions
 ======================================
@@ -41,6 +44,8 @@ Note: 22X, 23X and 24X has not had asyncio-specific suggestions written.
 - **ASYNC240**: Avoid using ``os.path`` in async functions, prefer using ``[trio/anyio].Path`` objects. ``asyncio`` users should consider `aiopath <https://pypi.org/project/aiopath>`_ or `anyio <https://github.com/agronholm/anyio>`_.
 - **ASYNC250**: Builtin ``input()`` should not be called from async function. Wrap in ``[trio/anyio].to_thread.run_sync()`` or ``asyncio.loop.run_in_executor()``.
 - **ASYNC251**: ``time.sleep(...)`` should not be called from async function. Use ``[trio/anyio/asyncio].sleep(...)``.
+
+.. _async900:
 
 Optional rules disabled by default
 ==================================

--- a/flake8_async/__init__.py
+++ b/flake8_async/__init__.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
 
 
 # CalVer: YY.month.patch, e.g. first release of July 2022 == "22.7.1"
-__version__ = "24.4.1"
+__version__ = "24.4.2"
 
 
 # taken from https://github.com/Zac-HD/shed

--- a/flake8_async/visitors/visitors.py
+++ b/flake8_async/visitors/visitors.py
@@ -290,35 +290,33 @@ class Visitor119(Flake8AsyncVisitor):
 
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
-        self.unsafe_function: ast.AsyncFunctionDef | None = None
-        self.contextmanager: ast.With | ast.AsyncWith | None = None
+        self.unsafe_function: bool = False
+        self.contextmanager: bool = False
 
     def visit_AsyncFunctionDef(
         self, node: ast.AsyncFunctionDef | ast.FunctionDef | ast.Lambda
     ):
         self.save_state(node, "unsafe_function", "contextmanager")
-        self.contextmanager = None
+        self.contextmanager = False
         if isinstance(node, ast.AsyncFunctionDef) and not has_decorator(
             node, "asynccontextmanager"
         ):
-            self.unsafe_function = node
+            self.unsafe_function = True
         else:
-            self.unsafe_function = None
+            self.unsafe_function = False
 
     def visit_With(self, node: ast.With | ast.AsyncWith):
         self.save_state(node, "contextmanager")
-        self.contextmanager = node
+        self.contextmanager = True
 
     def visit_Yield(self, node: ast.Yield):
-        if self.unsafe_function is not None and self.contextmanager is not None:
-            # Decision point: the error could point to the method, or context manager,
-            # or the yield.
+        if self.unsafe_function and self.contextmanager:
             self.error(node)
-            # only warn once per method (?)
-            self.unsafe_function = None
 
     visit_AsyncWith = visit_With
     visit_FunctionDef = visit_AsyncFunctionDef
+    # it's not possible to yield or open context managers in lambda's, so this
+    # one isn't strictly needed afaik.
     visit_Lambda = visit_AsyncFunctionDef
 
 

--- a/tests/eval_files/async119.py
+++ b/tests/eval_files/async119.py
@@ -1,0 +1,55 @@
+import contextlib
+
+from contextlib import asynccontextmanager
+
+
+async def unsafe_yield():
+    with open(""):
+        yield  # error: 8
+
+
+async def async_with():
+    async with unsafe_yield():
+        yield  # error: 8
+
+
+async def yield_not_in_contextmanager():
+    yield
+    with open(""):
+        ...
+    yield
+
+
+async def yield_in_nested_function():
+    with open(""):
+
+        def foo():
+            yield
+
+
+async def yield_in_nested_async_function():
+    with open(""):
+
+        async def foo():
+            yield
+
+
+async def yield_after_nested_async_function():
+    with open(""):
+
+        async def foo():
+            yield
+
+        yield  # error: 8
+
+
+@asynccontextmanager
+async def safe_in_contextmanager():
+    with open(""):
+        yield
+
+
+@contextlib.asynccontextmanager
+async def safe_in_contextmanager2():
+    with open(""):
+        yield

--- a/tests/eval_files/async119.py
+++ b/tests/eval_files/async119.py
@@ -13,6 +13,15 @@ async def async_with():
         yield  # error: 8
 
 
+async def warn_on_yeach_yield():
+    with open(""):
+        yield  # error: 8
+        yield  # error: 8
+    with open(""):
+        yield  # error: 8
+        yield  # error: 8
+
+
 async def yield_not_in_contextmanager():
     yield
     with open(""):


### PR DESCRIPTION
See #211 
@alicederyn

The issue is somewhat confusing at times to parse out what discussing pertains to async119 vs async102 vs hypotheticals, but I think this is what was settled upon.


I *think* this is a false positive with current implementation
```python
async def foo():
    with open(""):
      yield
```
i.e. the contextmanager is sync (and there are no awaits after the contextmanager?). Resolving that wouldn't be terribly complicated so I'll implement that if somebody confirms my understanding.


I didn't put much energy in formatting the entry in the readme, as that is on its way out. The links in the docs would probably be much cleaner with intersphinx or something, but leaving that for a different PR.