### PR TITLE
add codeautolink

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,6 +19,7 @@ build:
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
     configuration: docs/conf.py
+    fail_on_warning: true
 
 # Optionally build your docs in additional formats such as PDF and ePub
 # formats:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,6 +27,7 @@ release = version
 
 extensions: list[str] = [
     "sphinx.ext.intersphinx",
+    "sphinx_codeautolink",
 ]
 
 intersphinx_mapping = {
@@ -38,6 +39,11 @@ intersphinx_mapping = {
     # see https://github.com/encode/httpx/discussions/1220
     # we only have a few references to httpx though, so can just link manually.
 }
+
+# these are disabled by default, might re-disable them if they turn out to be noisy
+codeautolink_warn_on_missing_inventory = True
+codeautolink_warn_on_failed_resolve = True
+
 templates_path = ["_templates"]
 exclude_patterns: list[str] = ["_build", "Thumbs.db", ".DS_Store"]
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
 libcst
+sphinx-codeautolink


### PR DESCRIPTION
The documentation doesn't actually have any code examples that makes use of it (yet, #248) but I added it for the sake of reproducing https://github.com/felix-hilden/sphinx-codeautolink/issues/142 and thought I might as well commit it as a small PR.