### PR TITLE
add --exception-suppress-context-manager

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -56,6 +56,8 @@ install and run as standalone
 
 If inside a git repository, running without arguments will run it against all ``*.py`` files in the repository.
 
+Note that this does not currently support reading config files, and does not respect ``# noqa`` comments.
+
 .. code-block:: sh
 
    pip install flake8-async
@@ -229,6 +231,27 @@ Example
      mydecoratorpackage.checkpointing_decorators.*,
      ign*,
      *.ignore,
+
+``exception-suppress-context-managers``
+---------------------------------------
+
+
+Comma-separated list of contextmanagers which may suppress exceptions
+without reraising, breaking checkpoint guarantees of ASYNC91x.
+``contextlib.suppress`` will be added to the list after parsing.
+Decorators can be dotted or not, as well as support * as a wildcard.
+
+Example
+^^^^^^^
+
+.. code-block:: none
+
+   exception-suppress-context-managers =
+     mysuppressor,
+     dangerouslibrary.*,
+     *.suppress,
+     suppress
+
 
 .. _--startable-in-context-manager:
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -237,8 +237,11 @@ Example
 
 
 Comma-separated list of contextmanagers which may suppress exceptions
-without reraising, breaking checkpoint guarantees of ASYNC91x.
-``contextlib.suppress`` will be added to the list after parsing.
+without reraising. For ASYNC91x, these will be parsed in the worst-case scenario,
+where any checkpoints inside the contextmanager are not executed, and all
+exceptions are suppressed.
+``contextlib.suppress`` will be added to the list after parsing, and some basic parsing
+of ``from contextlib import suppress`` is supported.
 Decorators can be dotted or not, as well as support * as a wildcard.
 
 Example
@@ -250,7 +253,6 @@ Example
      mysuppressor,
      dangerouslibrary.*,
      *.suppress,
-     suppress
 
 
 .. _--startable-in-context-manager:

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -244,6 +244,9 @@ exceptions are suppressed.
 of ``from contextlib import suppress`` is supported.
 Decorators can be dotted or not, as well as support * as a wildcard.
 
+If you want to be extremely pessimistic, you can specify ``*`` as the context manager.
+We may add a whitelist option in the future to support this use-case better.
+
 Example
 ^^^^^^^
 

--- a/flake8_async/__init__.py
+++ b/flake8_async/__init__.py
@@ -262,6 +262,18 @@ class Plugin:
             ),
         )
         add_argument(
+            "--exception-suppress-context-managers",
+            default="",
+            required=False,
+            type=comma_separated_list,
+            help=(
+                "Comma-separated list of contextmanagers which may suppress exceptions "
+                "without reraising, breaking checkpoint guarantees of ASYNC91x. "
+                "``contextlib.suppress`` will be added to the list. "
+                "Decorators can be dotted or not, as well as support * as a wildcard. "
+            ),
+        )
+        add_argument(
             "--startable-in-context-manager",
             type=parse_async114_identifiers,
             default="",
@@ -379,6 +391,7 @@ class Plugin:
             autofix_codes=autofix_codes,
             error_on_autofix=options.error_on_autofix,
             no_checkpoint_warning_decorators=options.no_checkpoint_warning_decorators,
+            exception_suppress_context_managers=options.exception_suppress_context_managers,
             startable_in_context_manager=options.startable_in_context_manager,
             async200_blocking_calls=options.async200_blocking_calls,
             anyio=options.anyio,

--- a/flake8_async/base.py
+++ b/flake8_async/base.py
@@ -29,6 +29,7 @@ class Options:
     # whether to print an error message even when autofixed
     error_on_autofix: bool
     no_checkpoint_warning_decorators: Collection[str]
+    exception_suppress_context_managers: Collection[str]
     startable_in_context_manager: Collection[str]
     async200_blocking_calls: dict[str, str]
     anyio: bool

--- a/flake8_async/visitors/helpers.py
+++ b/flake8_async/visitors/helpers.py
@@ -112,7 +112,8 @@ def fnmatch_qualified_name(name_list: list[ast.expr], *patterns: str) -> str | N
 
 
 def fnmatch_qualified_name_cst(
-    name_list: Iterable[cst.Decorator], *patterns: str
+    name_list: Iterable[cst.Decorator | cst.Call | cst.Attribute | cst.Name],
+    *patterns: str,
 ) -> str | None:
     for name in name_list:
         qualified_name = get_full_name_for_node_or_raise(name)

--- a/tests/autofix_files/async910.py
+++ b/tests/autofix_files/async910.py
@@ -3,6 +3,7 @@
 # mypy: disable-error-code="unreachable"
 from __future__ import annotations
 
+import contextlib
 import typing
 from typing import Any, overload
 

--- a/tests/autofix_files/exception_suppress_context_manager.py
+++ b/tests/autofix_files/exception_suppress_context_manager.py
@@ -1,0 +1,90 @@
+# ARG --exception-suppress-context-managers=mysuppress,*.dangerousname,dangerouslibrary.*
+# ARG --enable=ASYNC910,ASYNC911
+
+# AUTOFIX
+# ASYNCIO_NO_AUTOFIX
+
+# 912 is tested in eval_files/async912.py to avoid problems with autofix/asyncio
+
+import contextlib
+from contextlib import suppress
+from typing import Any
+
+import trio
+
+mysuppress: Any
+anything: Any
+dangerouslibrary: Any
+
+
+async def foo() -> Any:
+    await foo()
+
+
+async def foo_suppress():  # ASYNC910: 0, "exit", Statement('function definition', lineno)
+    with contextlib.suppress():
+        await foo()
+    await trio.lowlevel.checkpoint()
+
+
+async def foo_suppress_1():  # ASYNC910: 0, "exit", Statement('function definition', lineno)
+    with mysuppress():
+        await foo()
+    await trio.lowlevel.checkpoint()
+
+
+async def foo_suppress_2():  # ASYNC910: 0, "exit", Statement('function definition', lineno)
+    with anything.dangerousname():
+        await foo()
+    await trio.lowlevel.checkpoint()
+
+
+async def foo_suppress_3():  # ASYNC910: 0, "exit", Statement('function definition', lineno)
+    with dangerouslibrary.anything():
+        await foo()
+    await trio.lowlevel.checkpoint()
+
+
+# not enabled by default
+# it probably wouldn't be too bad to track 'from contextlib import suppress'
+async def foo_suppress_4():
+    with suppress():
+        await foo()
+
+
+async def foo_suppress_async911():  # ASYNC911: 0, "exit", Statement("function definition", lineno)
+    with contextlib.suppress():
+        await foo()
+        yield
+        await foo()
+    await trio.lowlevel.checkpoint()
+
+
+# the `async with` checkpoints, so there's no error
+async def foo_suppress_async():
+    async with mysuppress:
+        await foo()
+
+
+async def foo_multiple():  # ASYNC910: 0, "exit", Statement('function definition', lineno)
+    with anything, contextlib.suppress():
+        await foo()
+    await trio.lowlevel.checkpoint()
+
+
+# we only match on *calls*
+async def foo_no_call():
+    with contextlib.suppress:  # type: ignore[attr-defined]
+        await foo()
+
+
+# doesn't work on namedexpr, but those should use `as` anyway
+async def foo_namedexpr():
+    with (ref := contextlib.suppress()):
+        await foo()
+
+
+async def foo_suppress_as():  # ASYNC910: 0, "exit", Statement('function definition', lineno)
+    with contextlib.suppress() as my_suppressor:
+        await foo()
+    await trio.lowlevel.checkpoint()

--- a/tests/autofix_files/exception_suppress_context_manager.py.diff
+++ b/tests/autofix_files/exception_suppress_context_manager.py.diff
@@ -1,0 +1,49 @@
+---
++++
+@@ x,21 x,25 @@
+ async def foo_suppress():  # ASYNC910: 0, "exit", Statement('function definition', lineno)
+     with contextlib.suppress():
+         await foo()
++    await trio.lowlevel.checkpoint()
+
+
+ async def foo_suppress_1():  # ASYNC910: 0, "exit", Statement('function definition', lineno)
+     with mysuppress():
+         await foo()
++    await trio.lowlevel.checkpoint()
+
+
+ async def foo_suppress_2():  # ASYNC910: 0, "exit", Statement('function definition', lineno)
+     with anything.dangerousname():
+         await foo()
++    await trio.lowlevel.checkpoint()
+
+
+ async def foo_suppress_3():  # ASYNC910: 0, "exit", Statement('function definition', lineno)
+     with dangerouslibrary.anything():
+         await foo()
++    await trio.lowlevel.checkpoint()
+
+
+ # not enabled by default
+@@ x,6 x,7 @@
+         await foo()
+         yield
+         await foo()
++    await trio.lowlevel.checkpoint()
+
+
+ # the `async with` checkpoints, so there's no error
+@@ x,6 x,7 @@
+ async def foo_multiple():  # ASYNC910: 0, "exit", Statement('function definition', lineno)
+     with anything, contextlib.suppress():
+         await foo()
++    await trio.lowlevel.checkpoint()
+
+
+ # we only match on *calls*
+@@ x,3 x,4 @@
+ async def foo_suppress_as():  # ASYNC910: 0, "exit", Statement('function definition', lineno)
+     with contextlib.suppress() as my_suppressor:
+         await foo()
++    await trio.lowlevel.checkpoint()

--- a/tests/autofix_files/exception_suppress_context_manager.py.diff
+++ b/tests/autofix_files/exception_suppress_context_manager.py.diff
@@ -25,7 +25,7 @@
 +    await trio.lowlevel.checkpoint()
 
 
- # not enabled by default
+ async def foo_suppress_async911():  # ASYNC911: 0, "exit", Statement("function definition", lineno)
 @@ x,6 x,7 @@
          await foo()
          yield
@@ -42,8 +42,62 @@
 
 
  # we only match on *calls*
-@@ x,3 x,4 @@
+@@ x,6 x,7 @@
  async def foo_suppress_as():  # ASYNC910: 0, "exit", Statement('function definition', lineno)
      with contextlib.suppress() as my_suppressor:
          await foo()
 +    await trio.lowlevel.checkpoint()
+
+
+ # ###############################
+@@ x,6 x,7 @@
+ async def foo_suppress_directly_imported_2():  # ASYNC910: 0, "exit", Statement('function definition', lineno)
+     with suppress():
+         await foo()
++    await trio.lowlevel.checkpoint()
+
+
+ # it also supports importing with an alias
+@@ x,12 x,14 @@
+ async def foo_suppress_directly_imported_3():  # ASYNC910: 0, "exit", Statement('function definition', lineno)
+     with adifferentname():
+         await foo()
++    await trio.lowlevel.checkpoint()
+
+
+ # and will keep track of all identifiers it's been assigned as
+ async def foo_suppress_directly_imported_4():  # ASYNC910: 0, "exit", Statement('function definition', lineno)
+     with suppress():
+         await foo()
++    await trio.lowlevel.checkpoint()
+
+
+ # basic function scoping is supported
+@@ x,9 x,11 @@
+
+     with adifferentname():
+         await foo()
++    await trio.lowlevel.checkpoint()
+     yield  # ASYNC911: 4, "yield", Stmt("function definition", lineno-5)
+     with bar():
+         await foo()
++    await trio.lowlevel.checkpoint()
+     yield  # ASYNC911: 4, "yield", Stmt("yield", lineno-3)
+     await foo()
+
+@@ x,6 x,7 @@
+ async def foo_suppress_directly_imported_restored_after_scope():  # ASYNC910: 0, "exit", Statement('function definition', lineno)
+     with adifferentname():
+         await foo()
++    await trio.lowlevel.checkpoint()
+
+
+ # We don't track the identifier being overridden though.
+@@ x,6 x,7 @@
+ async def foo_suppress_directly_imported_5():  # ASYNC910: 0, "exit", Statement('function definition', lineno)
+     with adifferentname():
+         await foo()
++    await trio.lowlevel.checkpoint()
+
+
+ # or assignments to different identifiers

--- a/tests/autofix_files/exception_suppress_context_manager_import_star.py
+++ b/tests/autofix_files/exception_suppress_context_manager_import_star.py
@@ -1,0 +1,16 @@
+# ARG --enable=ASYNC910
+# see exception_suppress_context_manager.py for main testing
+
+# AUTOFIX
+# ASYNCIO_NO_AUTOFIX
+
+from contextlib import *
+
+# NOTE: remove in #255
+import trio
+
+
+async def foo():  # ASYNC910: 0, "exit", Statement('function definition', lineno)
+    with suppress():
+        await foo()
+    await trio.lowlevel.checkpoint()

--- a/tests/autofix_files/exception_suppress_context_manager_import_star.py.diff
+++ b/tests/autofix_files/exception_suppress_context_manager_import_star.py.diff
@@ -1,0 +1,7 @@
+---
++++
+@@ x,3 x,4 @@
+ async def foo():  # ASYNC910: 0, "exit", Statement('function definition', lineno)
+     with suppress():
+         await foo()
++    await trio.lowlevel.checkpoint()

--- a/tests/eval_files/async910.py
+++ b/tests/eval_files/async910.py
@@ -3,6 +3,7 @@
 # mypy: disable-error-code="unreachable"
 from __future__ import annotations
 
+import contextlib
 import typing
 from typing import Any, overload
 

--- a/tests/eval_files/async912.py
+++ b/tests/eval_files/async912.py
@@ -7,6 +7,7 @@
 # of not testing both in the same file, or running with NOAUTOFIX.
 # NOAUTOFIX
 
+import contextlib
 from typing import TypeVar
 
 import trio
@@ -152,12 +153,18 @@ async def livelocks_2():
                 pass
 
 
-# TODO: add --async912-context-managers=
+# TODO: no-guaranteed-checkpoint-in-infinite-loop
+# https://github.com/python-trio/flake8-async/issues/240
 async def livelocks_3():
-    import contextlib
-
     with trio.move_on_after(0.1):  # should error
         while True:
+            with contextlib.suppress(TypeError):
+                await trio.sleep("1")  # type: ignore
+
+
+async def livelocks_4():
+    with trio.move_on_after(0.1):  # ASYNC912: 9
+        while condition():
             with contextlib.suppress(TypeError):
                 await trio.sleep("1")  # type: ignore
 

--- a/tests/eval_files/exception_suppress_context_manager.py
+++ b/tests/eval_files/exception_suppress_context_manager.py
@@ -7,7 +7,6 @@
 # 912 is tested in eval_files/async912.py to avoid problems with autofix/asyncio
 
 import contextlib
-from contextlib import suppress
 from typing import Any
 
 import trio
@@ -38,13 +37,6 @@ async def foo_suppress_2():  # ASYNC910: 0, "exit", Statement('function definiti
 
 async def foo_suppress_3():  # ASYNC910: 0, "exit", Statement('function definition', lineno)
     with dangerouslibrary.anything():
-        await foo()
-
-
-# not enabled by default
-# it probably wouldn't be too bad to track 'from contextlib import suppress'
-async def foo_suppress_4():
-    with suppress():
         await foo()
 
 
@@ -80,4 +72,86 @@ async def foo_namedexpr():
 
 async def foo_suppress_as():  # ASYNC910: 0, "exit", Statement('function definition', lineno)
     with contextlib.suppress() as my_suppressor:
+        await foo()
+
+
+# ###############################
+# from contextlib import suppress
+# ###############################
+
+
+# not enabled unless it's imported from contextlib
+async def foo_suppress_directly_imported_1():
+    with suppress():
+        await foo()
+
+
+from contextlib import suppress
+
+
+# now it's enabled
+async def foo_suppress_directly_imported_2():  # ASYNC910: 0, "exit", Statement('function definition', lineno)
+    with suppress():
+        await foo()
+
+
+# it also supports importing with an alias
+from contextlib import suppress as adifferentname
+
+
+async def foo_suppress_directly_imported_3():  # ASYNC910: 0, "exit", Statement('function definition', lineno)
+    with adifferentname():
+        await foo()
+
+
+# and will keep track of all identifiers it's been assigned as
+async def foo_suppress_directly_imported_4():  # ASYNC910: 0, "exit", Statement('function definition', lineno)
+    with suppress():
+        await foo()
+
+
+# basic function scoping is supported
+async def function_that_contains_the_import():
+    from contextlib import suppress as bar
+
+    with adifferentname():
+        await foo()
+    yield  # ASYNC911: 4, "yield", Stmt("function definition", lineno-5)
+    with bar():
+        await foo()
+    yield  # ASYNC911: 4, "yield", Stmt("yield", lineno-3)
+    await foo()
+
+
+# bar is not suppressing
+async def foo_suppress_directly_imported_scoped():
+    with bar():  # type: ignore[name-defined]
+        await foo()
+
+
+# adifferentname is still suppressing
+async def foo_suppress_directly_imported_restored_after_scope():  # ASYNC910: 0, "exit", Statement('function definition', lineno)
+    with adifferentname():
+        await foo()
+
+
+# We don't track the identifier being overridden though.
+adifferentname = None  # type: ignore[assignment]
+
+
+# shouldn't give an error
+async def foo_suppress_directly_imported_5():  # ASYNC910: 0, "exit", Statement('function definition', lineno)
+    with adifferentname():
+        await foo()
+
+
+# or assignments to different identifiers
+from contextlib import suppress
+
+my_second_suppress = suppress
+
+
+# should give an error
+async def foo_suppress_directly_imported_assignment():
+    with my_second_suppress():
         await foo()

--- a/tests/eval_files/exception_suppress_context_manager.py
+++ b/tests/eval_files/exception_suppress_context_manager.py
@@ -1,0 +1,83 @@
+# ARG --exception-suppress-context-managers=mysuppress,*.dangerousname,dangerouslibrary.*
+# ARG --enable=ASYNC910,ASYNC911
+
+# AUTOFIX
+# ASYNCIO_NO_AUTOFIX
+
+# 912 is tested in eval_files/async912.py to avoid problems with autofix/asyncio
+
+import contextlib
+from contextlib import suppress
+from typing import Any
+
+import trio
+
+mysuppress: Any
+anything: Any
+dangerouslibrary: Any
+
+
+async def foo() -> Any:
+    await foo()
+
+
+async def foo_suppress():  # ASYNC910: 0, "exit", Statement('function definition', lineno)
+    with contextlib.suppress():
+        await foo()
+
+
+async def foo_suppress_1():  # ASYNC910: 0, "exit", Statement('function definition', lineno)
+    with mysuppress():
+        await foo()
+
+
+async def foo_suppress_2():  # ASYNC910: 0, "exit", Statement('function definition', lineno)
+    with anything.dangerousname():
+        await foo()
+
+
+async def foo_suppress_3():  # ASYNC910: 0, "exit", Statement('function definition', lineno)
+    with dangerouslibrary.anything():
+        await foo()
+
+
+# not enabled by default
+# it probably wouldn't be too bad to track 'from contextlib import suppress'
+async def foo_suppress_4():
+    with suppress():
+        await foo()
+
+
+async def foo_suppress_async911():  # ASYNC911: 0, "exit", Statement("function definition", lineno)
+    with contextlib.suppress():
+        await foo()
+        yield
+        await foo()
+
+
+# the `async with` checkpoints, so there's no error
+async def foo_suppress_async():
+    async with mysuppress:
+        await foo()
+
+
+async def foo_multiple():  # ASYNC910: 0, "exit", Statement('function definition', lineno)
+    with anything, contextlib.suppress():
+        await foo()
+
+
+# we only match on *calls*
+async def foo_no_call():
+    with contextlib.suppress:  # type: ignore[attr-defined]
+        await foo()
+
+
+# doesn't work on namedexpr, but those should use `as` anyway
+async def foo_namedexpr():
+    with (ref := contextlib.suppress()):
+        await foo()
+
+
+async def foo_suppress_as():  # ASYNC910: 0, "exit", Statement('function definition', lineno)
+    with contextlib.suppress() as my_suppressor:
+        await foo()

--- a/tests/eval_files/exception_suppress_context_manager_import_star.py
+++ b/tests/eval_files/exception_suppress_context_manager_import_star.py
@@ -1,0 +1,15 @@
+# ARG --enable=ASYNC910
+# see exception_suppress_context_manager.py for main testing
+
+# AUTOFIX
+# ASYNCIO_NO_AUTOFIX
+
+from contextlib import *
+
+# NOTE: remove in #255
+import trio
+
+
+async def foo():  # ASYNC910: 0, "exit", Statement('function definition', lineno)
+    with suppress():
+        await foo()

--- a/tests/test_flake8_async.py
+++ b/tests/test_flake8_async.py
@@ -440,7 +440,7 @@ def _parse_eval_file(
                 msg = f"Line {lineno}: Failed to format\n {message!r}\nwith\n{args}"
                 raise ParseError(msg) from e
 
-    assert enabled_codes, "no codes enabled. Fix file name or add `# ARGS --enable=...`"
+    assert enabled_codes, "no codes enabled. Fix file name or add `# ARG --enable=...`"
     enabled_codes_list = enabled_codes.split(",")
     for code in enabled_codes_list:
         assert re.fullmatch(


### PR DESCRIPTION
Pretty straightforward. I wouldn't be totally shocked if this breaks something else in ASYNC91x, but I've spent a while trying to figure out edge cases and come up empty.

If you want support for `from contextlib import suppress` without having to specify `suppress` in the flag, it should be pretty doable to track the import like with other utility visitors.