### PR TITLE
Add ASYNC913, indefinite-loop-no-guaranteed-checkpoint. Fix async91x bugs

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 
 *[CalVer, YY.month.patch](https://calver.org/)*
 
-24.5.3
+24.5.4
 ======
 - Add ASYNC913: Indefinite loop with no guaranteed checkpoint.
 - Fix bugs in ASYNC910 and ASYNC911 autofixing where they sometimes didn't add a library import.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,12 @@ Changelog
 
 24.5.3
 ======
+- Add ASYNC913: Indefinite loop with no guaranteed checkpoint.
+- Fix bugs in ASYNC910 and ASYNC911 autofixing where they sometimes didn't add a library import.
+- Fix crash in ASYNC911 when trying to autofix a one-line ``while ...: yield``
+
+24.5.3
+======
 - Rename config option ``trio200-blocking-calls`` to :ref:`async200-blocking-calls`.
 - ``trio200-blocking-calls`` is now deprecated.
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,8 @@ Changelog
 - Add ASYNC913: Indefinite loop with no guaranteed checkpoint.
 - Fix bugs in ASYNC910 and ASYNC911 autofixing where they sometimes didn't add a library import.
 - Fix crash in ASYNC911 when trying to autofix a one-line ``while ...: yield``
+- Add :ref:`exception-suppress-context-managers`. Contextmanagers that may suppress exceptions.
+- ASYNC91x now treats checkpoints inside ``with contextlib.suppress`` as unreliable.
 
 24.5.3
 ======

--- a/docs/rules.rst
+++ b/docs/rules.rst
@@ -146,6 +146,9 @@ _`ASYNC912` : cancel-scope-no-guaranteed-checkpoint
     Similar to `ASYNC100`_, but it does not warn on trivial cases where there is no checkpoint at all.
     It instead shares logic with `ASYNC910`_ and `ASYNC911`_ for parsing conditionals and branches.
 
+_`ASYNC913` : indefinite-loop-no-guaranteed-checkpoint
+    An indefinite loop (e.g. ``while True``) has no guaranteed :ref:`checkpoint <checkpoint>`. This could potentially cause a deadlock.
+
 .. _autofix-support:
 
 Autofix support
@@ -154,6 +157,7 @@ The following rules support :ref:`autofixing <autofix>`.
 - :ref:`ASYNC100 <ASYNC100>`
 - :ref:`ASYNC910 <ASYNC910>`
 - :ref:`ASYNC911 <ASYNC911>`
+- :ref:`ASYNC913 <ASYNC913>`
 
 Removed rules
 ================

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -232,6 +232,8 @@ Example
      ign*,
      *.ignore,
 
+.. _exception-suppress-context-managers:
+
 ``exception-suppress-context-managers``
 ---------------------------------------
 

--- a/flake8_async/__init__.py
+++ b/flake8_async/__init__.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
 
 
 # CalVer: YY.month.patch, e.g. first release of July 2022 == "22.7.1"
-__version__ = "24.5.3"
+__version__ = "24.5.4"
 
 
 # taken from https://github.com/Zac-HD/shed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,9 @@ remove-all-unused-imports = true
 remove-duplicate-keys = true
 remove-unused-variables = true
 
+[tool.black]
+extend-exclude = "tests/autofix_files/.*.py"
+
 [tool.codespell]
 ignore-words-list = 'spawnve'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,8 @@ remove-duplicate-keys = true
 remove-unused-variables = true
 
 [tool.black]
-extend-exclude = "tests/autofix_files/.*.py"
+# need to use force-exclude since pre-commit directly specifies files
+force-exclude = "tests/autofix_files/.*.py"
 
 [tool.codespell]
 ignore-words-list = 'spawnve'
@@ -19,7 +20,7 @@ profile = "black"
 py_version = "311"
 quiet = true
 skip_gitignore = true
-skip_glob = "tests/eval_files/*"
+skip_glob = "tests/*_files/*"
 
 [tool.mypy]
 check_untyped_defs = true

--- a/tests/autofix_files/async910_insert_library.py
+++ b/tests/autofix_files/async910_insert_library.py
@@ -5,8 +5,6 @@
 
 
 import trio
-
-
 def condition() -> bool:
     return False
 

--- a/tests/autofix_files/async910_insert_library.py
+++ b/tests/autofix_files/async910_insert_library.py
@@ -1,0 +1,16 @@
+# ensure that import gets added when adding checkpoints at end of function body
+
+# AUTOFIX
+# ASYNCIO_NO_AUTOFIX
+
+
+import trio
+
+
+def condition() -> bool:
+    return False
+
+
+async def foo():  # ASYNC910: 0, "exit", Stmt("function definition", line)
+    print()
+    await trio.lowlevel.checkpoint()

--- a/tests/autofix_files/async910_insert_library.py.diff
+++ b/tests/autofix_files/async910_insert_library.py.diff
@@ -1,0 +1,14 @@
+---
++++
+@@ x,9 x,11 @@
+ # ASYNCIO_NO_AUTOFIX
+
+
++import trio
+ def condition() -> bool:
+     return False
+
+
+ async def foo():  # ASYNC910: 0, "exit", Stmt("function definition", line)
+     print()
++    await trio.lowlevel.checkpoint()

--- a/tests/autofix_files/async911_insert_library.py
+++ b/tests/autofix_files/async911_insert_library.py
@@ -1,0 +1,19 @@
+# ensure that import gets added when adding checkpoints in loop body
+
+# AUTOFIX
+# ASYNCIO_NO_AUTOFIX
+
+
+import trio
+
+
+def condition() -> bool:
+    return False
+
+
+async def foo():
+    await foo()
+    while condition():
+        await trio.lowlevel.checkpoint()
+        yield  # ASYNC911: 8, "yield", Stmt("yield", lineno)
+    await foo()

--- a/tests/autofix_files/async911_insert_library.py
+++ b/tests/autofix_files/async911_insert_library.py
@@ -5,8 +5,6 @@
 
 
 import trio
-
-
 def condition() -> bool:
     return False
 

--- a/tests/autofix_files/async911_insert_library.py.diff
+++ b/tests/autofix_files/async911_insert_library.py.diff
@@ -1,0 +1,17 @@
+---
++++
+@@ x,6 x,7 @@
+ # ASYNCIO_NO_AUTOFIX
+
+
++import trio
+ def condition() -> bool:
+     return False
+
+@@ x,5 x,6 @@
+ async def foo():
+     await foo()
+     while condition():
++        await trio.lowlevel.checkpoint()
+         yield  # ASYNC911: 8, "yield", Stmt("yield", lineno)
+     await foo()

--- a/tests/autofix_files/async913.py
+++ b/tests/autofix_files/async913.py
@@ -54,6 +54,10 @@ async def foo_conditional_nested():
                 ...
 
 
+# various checks I added for my own sanity to ensure autofixes worked when multiple
+# codes simultaneously want to autofix.
+
+
 async def foo_indef_and_910():
     while True:  # ASYNC913: 4
         await trio.lowlevel.checkpoint()

--- a/tests/autofix_files/async913.py
+++ b/tests/autofix_files/async913.py
@@ -1,0 +1,89 @@
+# ARG --enable=ASYNC910,ASYNC911,ASYNC913
+# AUTOFIX
+# ASYNCIO_NO_AUTOFIX
+
+
+import trio
+
+
+def condition() -> bool:
+    return False
+
+
+async def foo():
+    while True:  # ASYNC913: 4
+        await trio.lowlevel.checkpoint()
+        ...
+
+
+async def foo2():
+    while True:
+        await foo()
+
+
+async def foo3():
+    while True:  # ASYNC913: 4
+        await trio.lowlevel.checkpoint()
+        if condition():
+            await foo()
+
+
+# ASYNC913 does not trigger on loops with break, but those will generally be handled
+# by 910/911/912 if necessary
+async def foo_break():  # ASYNC910: 0, "exit", Statement("function definition", lineno)
+    while True:
+        if condition():
+            break
+    await trio.lowlevel.checkpoint()
+
+
+# the inner loop will suppress the error in the outer loop
+async def foo_nested():
+    while True:
+        while True:  # ASYNC913: 8
+            await trio.lowlevel.checkpoint()
+            ...
+
+
+async def foo_conditional_nested():
+    while True:  # ASYNC913: 4
+        await trio.lowlevel.checkpoint()
+        if condition():
+            while True:  # ASYNC913: 12
+                await trio.lowlevel.checkpoint()
+                ...
+
+
+async def foo_indef_and_910():
+    while True:  # ASYNC913: 4
+        await trio.lowlevel.checkpoint()
+        if ...:
+            await foo()
+            return
+
+
+async def foo_indef_and_910_2():
+    while True:  # ASYNC913: 4
+        await trio.lowlevel.checkpoint()
+        if ...:
+            return  # ASYNC910: 12, "return", Stmt("function definition", line-3)
+
+
+async def foo_indef_and_911():
+    await foo()
+    while True:  # ASYNC913: 4
+        await trio.lowlevel.checkpoint()
+        if condition():
+            yield  # ASYNC911: 12, "yield", Stmt("yield", line)  # ASYNC911: 12, "yield", Stmt("yield", line+2)
+        if condition():
+            await trio.lowlevel.checkpoint()
+            yield  # ASYNC911: 12, "yield", Stmt("yield", line)  # ASYNC911: 12, "yield", Stmt("yield", line-2)  # ASYNC911: 12, "yield", Stmt("yield", line-2)
+
+
+async def foo_indef_and_911_2():
+    await foo()
+    while True:  # ASYNC913: 4
+        await trio.lowlevel.checkpoint()
+        while condition():
+            await trio.lowlevel.checkpoint()
+            yield  # ASYNC911: 12, "yield", Stmt("yield", line)

--- a/tests/autofix_files/async913.py
+++ b/tests/autofix_files/async913.py
@@ -4,8 +4,6 @@
 
 
 import trio
-
-
 def condition() -> bool:
     return False
 

--- a/tests/autofix_files/async913.py.diff
+++ b/tests/autofix_files/async913.py.diff
@@ -23,7 +23,7 @@
          if condition():
              await foo()
 
-@@ x,24 x,29 @@
+@@ x,19 x,23 @@
      while True:
          if condition():
              break
@@ -46,6 +46,8 @@
 +                await trio.lowlevel.checkpoint()
                  ...
 
+
+@@ x,6 x,7 @@
 
  async def foo_indef_and_910():
      while True:  # ASYNC913: 4

--- a/tests/autofix_files/async913.py.diff
+++ b/tests/autofix_files/async913.py.diff
@@ -1,0 +1,82 @@
+---
++++
+@@ x,12 x,14 @@
+ # ASYNCIO_NO_AUTOFIX
+
+
++import trio
+ def condition() -> bool:
+     return False
+
+
+ async def foo():
+     while True:  # ASYNC913: 4
++        await trio.lowlevel.checkpoint()
+         ...
+
+
+@@ x,6 x,7 @@
+
+ async def foo3():
+     while True:  # ASYNC913: 4
++        await trio.lowlevel.checkpoint()
+         if condition():
+             await foo()
+
+@@ x,24 x,29 @@
+     while True:
+         if condition():
+             break
++    await trio.lowlevel.checkpoint()
+
+
+ # the inner loop will suppress the error in the outer loop
+ async def foo_nested():
+     while True:
+         while True:  # ASYNC913: 8
++            await trio.lowlevel.checkpoint()
+             ...
+
+
+ async def foo_conditional_nested():
+     while True:  # ASYNC913: 4
++        await trio.lowlevel.checkpoint()
+         if condition():
+             while True:  # ASYNC913: 12
++                await trio.lowlevel.checkpoint()
+                 ...
+
+
+ async def foo_indef_and_910():
+     while True:  # ASYNC913: 4
++        await trio.lowlevel.checkpoint()
+         if ...:
+             await foo()
+             return
+@@ x,6 x,7 @@
+
+ async def foo_indef_and_910_2():
+     while True:  # ASYNC913: 4
++        await trio.lowlevel.checkpoint()
+         if ...:
+             return  # ASYNC910: 12, "return", Stmt("function definition", line-3)
+
+@@ x,14 x,18 @@
+ async def foo_indef_and_911():
+     await foo()
+     while True:  # ASYNC913: 4
++        await trio.lowlevel.checkpoint()
+         if condition():
+             yield  # ASYNC911: 12, "yield", Stmt("yield", line)  # ASYNC911: 12, "yield", Stmt("yield", line+2)
+         if condition():
++            await trio.lowlevel.checkpoint()
+             yield  # ASYNC911: 12, "yield", Stmt("yield", line)  # ASYNC911: 12, "yield", Stmt("yield", line-2)  # ASYNC911: 12, "yield", Stmt("yield", line-2)
+
+
+ async def foo_indef_and_911_2():
+     await foo()
+     while True:  # ASYNC913: 4
++        await trio.lowlevel.checkpoint()
+         while condition():
++            await trio.lowlevel.checkpoint()
+             yield  # ASYNC911: 12, "yield", Stmt("yield", line)

--- a/tests/autofix_files/exception_suppress_context_manager_import_star.py
+++ b/tests/autofix_files/exception_suppress_context_manager_import_star.py
@@ -5,8 +5,6 @@
 # ASYNCIO_NO_AUTOFIX
 
 from contextlib import *
-
-# NOTE: remove in #255
 import trio
 
 

--- a/tests/autofix_files/exception_suppress_context_manager_import_star.py.diff
+++ b/tests/autofix_files/exception_suppress_context_manager_import_star.py.diff
@@ -1,6 +1,12 @@
 ---
 +++
-@@ x,3 x,4 @@
+@@ x,8 x,10 @@
+ # ASYNCIO_NO_AUTOFIX
+
+ from contextlib import *
++import trio
+
+
  async def foo():  # ASYNC910: 0, "exit", Statement('function definition', lineno)
      with suppress():
          await foo()

--- a/tests/eval_files/async910_insert_library.py
+++ b/tests/eval_files/async910_insert_library.py
@@ -1,0 +1,12 @@
+# ensure that import gets added when adding checkpoints at end of function body
+
+# AUTOFIX
+# ASYNCIO_NO_AUTOFIX
+
+
+def condition() -> bool:
+    return False
+
+
+async def foo():  # ASYNC910: 0, "exit", Stmt("function definition", line)
+    print()

--- a/tests/eval_files/async911_insert_library.py
+++ b/tests/eval_files/async911_insert_library.py
@@ -1,0 +1,15 @@
+# ensure that import gets added when adding checkpoints in loop body
+
+# AUTOFIX
+# ASYNCIO_NO_AUTOFIX
+
+
+def condition() -> bool:
+    return False
+
+
+async def foo():
+    await foo()
+    while condition():
+        yield  # ASYNC911: 8, "yield", Stmt("yield", lineno)
+    await foo()

--- a/tests/eval_files/async912.py
+++ b/tests/eval_files/async912.py
@@ -129,7 +129,7 @@ async def foo():
             await trio.lowlevel.checkpoint()
 
 
-# TODO: issue #240
+# This is handled by ASYNC913, which will raise an error about the loop.
 async def livelocks():
     with trio.move_on_after(0.1):  # should error
         while True:

--- a/tests/eval_files/async913.py
+++ b/tests/eval_files/async913.py
@@ -1,0 +1,78 @@
+# ARG --enable=ASYNC910,ASYNC911,ASYNC913
+# AUTOFIX
+# ASYNCIO_NO_AUTOFIX
+
+
+def condition() -> bool:
+    return False
+
+
+async def foo():
+    while True:  # ASYNC913: 4
+        ...
+
+
+async def foo2():
+    while True:
+        await foo()
+
+
+async def foo3():
+    while True:  # ASYNC913: 4
+        if condition():
+            await foo()
+
+
+# ASYNC913 does not trigger on loops with break, but those will generally be handled
+# by 910/911/912 if necessary
+async def foo_break():  # ASYNC910: 0, "exit", Statement("function definition", lineno)
+    while True:
+        if condition():
+            break
+
+
+# the inner loop will suppress the error in the outer loop
+async def foo_nested():
+    while True:
+        while True:  # ASYNC913: 8
+            ...
+
+
+async def foo_conditional_nested():
+    while True:  # ASYNC913: 4
+        if condition():
+            while True:  # ASYNC913: 12
+                ...
+
+
+# various checks I added for my own sanity to ensure autofixes worked when multiple
+# codes simultaneously want to autofix.
+
+
+async def foo_indef_and_910():
+    while True:  # ASYNC913: 4
+        if ...:
+            await foo()
+            return
+
+
+async def foo_indef_and_910_2():
+    while True:  # ASYNC913: 4
+        if ...:
+            return  # ASYNC910: 12, "return", Stmt("function definition", line-3)
+
+
+async def foo_indef_and_911():
+    await foo()
+    while True:  # ASYNC913: 4
+        if condition():
+            yield  # ASYNC911: 12, "yield", Stmt("yield", line)  # ASYNC911: 12, "yield", Stmt("yield", line+2)
+        if condition():
+            yield  # ASYNC911: 12, "yield", Stmt("yield", line)  # ASYNC911: 12, "yield", Stmt("yield", line-2)  # ASYNC911: 12, "yield", Stmt("yield", line-2)
+
+
+async def foo_indef_and_911_2():
+    await foo()
+    while True:  # ASYNC913: 4
+        while condition():
+            yield  # ASYNC911: 12, "yield", Stmt("yield", line)

--- a/tests/eval_files/async91x_noautofix.py
+++ b/tests/eval_files/async91x_noautofix.py
@@ -1,4 +1,4 @@
-# ARG --enable=ASYNC910,ASYNC911
+# ARG --enable=ASYNC910,ASYNC911,ASYNC913
 from typing import Any
 
 
@@ -72,3 +72,23 @@ async def foo_boolops_2():
         and (yield)  # ASYNC911: 13, "yield", Stmt("yield", line-2, 13)
     )
     await foo()
+
+
+async def foo_sameline_913():
+    # fmt: off
+    while True: ...  # ASYNC913: 4
+    # fmt: on
+
+
+# this previously caused a crash
+async def foo_sameline_911():
+    await foo()
+    # fmt: off
+    while True: yield  # ASYNC911: 16, "yield", Stmt("yield", lineno)
+    # fmt: on
+
+
+# this was guarded by an isinstance check though
+# fmt: off
+async def foo_sameline_910(): print()  # ASYNC910: 0, "exit", Stmt("function definition", line)
+# fmt: on

--- a/tests/eval_files/exception_suppress_context_manager_import_star.py
+++ b/tests/eval_files/exception_suppress_context_manager_import_star.py
@@ -6,9 +6,6 @@
 
 from contextlib import *
 
-# NOTE: remove in #255
-import trio
-
 
 async def foo():  # ASYNC910: 0, "exit", Statement('function definition', lineno)
     with suppress():


### PR DESCRIPTION
Adds a new check ASYNC913, indefinite-loop-no-guaranteed-checkpoint.

Will likely have some minor merge conflicts with #254 
Fixes #240.
Together with #254 it fixes the example given in #227. The error will be for the loop though, and not the context manager.

I also noticed a few bugs when implementing it, that also are fixed
* ASYNC911 crashed when trying to autofix
```python
while True: yield
```
because the autofix assumed the loop body was an `IndentedBlock`.
* ASYNC911 didn't add a library import when using InsertCheckPointsInLoopBody, i.e. when a checkpoint was needed due to the artificial statement injected at start of loop body. See eval_files/async911_insert_library.py
* ASYNC910 didn't add a library import when adding a checkpoint at the end of a function body. (as opposed to before a `return`). See eval_files/async910_insert_library.py