### PR TITLE
various small fixes

### DIFF
--- a/docs/rules.rst
+++ b/docs/rules.rst
@@ -55,9 +55,9 @@ ASYNC112 : useless-nursery
 
 _`ASYNC113` : start-soon-in-aenter
     Using :meth:`~trio.Nursery.start_soon`/:meth:`~anyio.abc.TaskGroup.start_soon` in ``__aenter__`` doesn't wait for the task to begin.
-    This will only warn about built-in functions and those listed in _`ASYNC114`.
-    If you're starting a function that does not define `task_status`, then neither will trigger.
     Consider replacing with :meth:`~trio.Nursery.start`/:meth:`~anyio.abc.TaskGroup.start`.
+    This will only warn about functions listed in :ref:`ASYNC114 <async114>` or known from Trio.
+    If you're starting a function that does not define `task_status`, then neither will trigger.
 
 _`ASYNC114` : startable-not-in-config
     Startable function (i.e. has a ``task_status`` keyword parameter) not in :ref:`--startable-in-context-manager <--startable-in-context-manager>` parameter list, please add it so ASYNC113 can catch errors when using it.

--- a/docs/rules.rst
+++ b/docs/rules.rst
@@ -55,6 +55,8 @@ ASYNC112 : useless-nursery
 
 _`ASYNC113` : start-soon-in-aenter
     Using :meth:`~trio.Nursery.start_soon`/:meth:`~anyio.abc.TaskGroup.start_soon` in ``__aenter__`` doesn't wait for the task to begin.
+    This will only warn about built-in functions and those listed in _`ASYNC114`.
+    If you're starting a function that does not define `task_status`, then neither will trigger.
     Consider replacing with :meth:`~trio.Nursery.start`/:meth:`~anyio.abc.TaskGroup.start`.
 
 _`ASYNC114` : startable-not-in-config

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -265,8 +265,9 @@ Example
 ``startable-in-context-manager``
 --------------------------------
 
-Comma-separated list of methods which should be used with :meth:`trio.Nursery.start`/:meth:`anyio.abc.TaskGroup.start` when opening a context manager,
-in addition to the default :func:`trio.run_process`, :func:`trio.serve_tcp`, :func:`trio.serve_ssl_over_tcp`, and :func:`trio.serve_listeners`.
+Comma-separated list of methods which should be used with :meth:`trio.Nursery.start`/:meth:`anyio.abc.TaskGroup.start` when opening a context manager.
+This includes startable functions in the trio and anyio standard library by default, namely :func:`trio.run_process`, :func:`trio.serve_tcp`, :func:`trio.serve_ssl_over_tcp`, :func:`trio.serve_listeners`, :func:`trio.serve`, :func:`anyio.run_process`, :func:`anyio.serve_tcp`, :func:`anyio.serve_ssl_over_tcp`, :func:`anyio.serve_listeners`, and :func:`anyio.serve`.
+
 Names must be valid identifiers as per :meth:`str.isidentifier`.
 Used by :ref:`ASYNC113 <async113>`, and :ref:`ASYNC114 <async114>` will warn when encountering methods not in the list.
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -265,8 +265,10 @@ Example
 ``startable-in-context-manager``
 --------------------------------
 
-Comma-separated list of methods which should be used with :meth:`trio.Nursery.start`/:meth:`anyio.abc.TaskGroup.start` when opening a context manager.
-This includes startable functions in the trio and anyio standard library by default, namely :func:`trio.run_process`, :func:`trio.serve_tcp`, :func:`trio.serve_ssl_over_tcp`, :func:`trio.serve_listeners`, :func:`trio.serve`, :func:`anyio.run_process`, :func:`anyio.serve_tcp`, :func:`anyio.serve_ssl_over_tcp`, :func:`anyio.serve_listeners`, and :func:`anyio.serve`.
+Comma-separated list of functions which should be used with :meth:`trio.Nursery.start`/:meth:`anyio.abc.TaskGroup.start` when opening a context manager.
+We then add known functions from Trio to this list, namely :func:`trio.run_process`, :func:`trio.serve_tcp`, :func:`trio.serve_ssl_over_tcp`, :func:`trio.serve_listeners`, and :meth:`trio.DTLSEndpoint.serve`.
+AnyIO does not have any functions in its API that defines ``task_status``.
+asyncio does not have an equivalent of :meth:`~trio.Nursery.start`, nor ``task_status``, but you could still add functions to this list that you want to be extra careful about when opening in an `asyncio.TaskGroup` in an ``__aenter__``
 
 Names must be valid identifiers as per :meth:`str.isidentifier`.
 Used by :ref:`ASYNC113 <async113>`, and :ref:`ASYNC114 <async114>` will warn when encountering methods not in the list.

--- a/flake8_async/visitors/visitor102.py
+++ b/flake8_async/visitors/visitor102.py
@@ -87,9 +87,7 @@ class Visitor102(Flake8AsyncVisitor):
 
         # Check for a `with trio.<scope_creator>`
         for item in node.items:
-            call = get_matching_call(
-                item.context_expr, "open_nursery", *cancel_scope_names
-            )
+            call = get_matching_call(item.context_expr, *cancel_scope_names)
             if call is None:
                 continue
 

--- a/flake8_async/visitors/visitors.py
+++ b/flake8_async/visitors/visitors.py
@@ -127,6 +127,7 @@ class Visitor112(Flake8AsyncVisitor):
                 nursery_type = "taskgroup"
                 start_methods = ("create_task",)
             else:
+                assert True
                 continue
 
             body_call = node.body[0].value

--- a/flake8_async/visitors/visitors.py
+++ b/flake8_async/visitors/visitors.py
@@ -127,7 +127,6 @@ class Visitor112(Flake8AsyncVisitor):
                 nursery_type = "taskgroup"
                 start_methods = ("create_task",)
             else:
-                assert True
                 continue
 
             body_call = node.body[0].value

--- a/tests/eval_files/async102.py
+++ b/tests/eval_files/async102.py
@@ -111,7 +111,9 @@ async def foo():
         myvar = True
         with trio.open_nursery(10) as s:
             s.shield = myvar
-            await foo()  # safe in theory, error: 12, Statement("try/finally", lineno-6)
+            # this is not safe in theory - because `trio.open_nursery` is an async cm,
+            # so it's not possible to open a nursery at all.
+            await foo()  # error: 12, Statement("try/finally", lineno-8)
     try:
         pass
     finally:

--- a/tests/eval_files/async102.py
+++ b/tests/eval_files/async102.py
@@ -109,10 +109,18 @@ async def foo():
         pass
     finally:
         myvar = True
-        with trio.open_nursery(10) as s:
-            s.shield = myvar
-            # this is not safe in theory - because `trio.open_nursery` is an async cm,
-            # so it's not possible to open a nursery at all.
+        with trio.CancelScope(deadline=10) as cs:
+            cs.shield = myvar
+            # safe in theory, but we don't track variable values
+            await foo()  # error: 12, Statement("try/finally", lineno-7)
+    try:
+        pass
+    finally:
+        # false alarm, open_nursery does not block/checkpoint on entry.
+        async with trio.open_nursery() as nursery:  # error: 8, Statement("try/finally", lineno-4)
+            nursery.cancel_scope.deadline = trio.current_time() + 10
+            nursery.cancel_scope.shield = True
+            # false alarm, we currently don't handle nursery.cancel_scope.[deadline/shield]
             await foo()  # error: 12, Statement("try/finally", lineno-8)
     try:
         pass

--- a/tests/eval_files/async112.py
+++ b/tests/eval_files/async112.py
@@ -9,34 +9,34 @@ import trio
 import trio as noterror
 
 # error
-with trio.open_nursery() as n:  # error: 5, "n"
+with trio.open_nursery() as n:  # error: 5, "n", "nursery"
     n.start(...)
 
-with trio.open_nursery(...) as nurse:  # error: 5, "nurse"
+with trio.open_nursery(...) as nurse:  # error: 5, "nurse", "nursery"
     nurse.start_soon(...)
 
-with trio.open_nursery() as n:  # error: 5, "n"
+with trio.open_nursery() as n:  # error: 5, "n", "nursery"
     n.start_soon(n=7)
 
 
 async def foo():
-    async with trio.open_nursery() as n:  # error: 15, "n"
+    async with trio.open_nursery() as n:  # error: 15, "n", "nursery"
         n.start(...)
 
 
 # weird ones with multiple `withitem`s
 # but if split among several `with` they'd all be treated as error (or ASYNC111), so
 # treating as error for now.
-with trio.open_nursery() as n, trio.open("") as n:  # error: 5, "n"
+with trio.open_nursery() as n, trio.open("") as n:  # error: 5, "n", "nursery"
     n.start(...)
 
-with open("") as o, trio.open_nursery() as n:  # error: 20, "n"
+with open("") as o, trio.open_nursery() as n:  # error: 20, "n", "nursery"
     n.start(o)
 
-with trio.open_nursery() as n, trio.open_nursery() as nurse:  # error: 31, "nurse"
+with trio.open_nursery() as n, trio.open_nursery() as nurse:  # error: 31, "nurse", "nursery"
     nurse.start(n.start(...))
 
-with trio.open_nursery() as n, trio.open_nursery() as n:  # error: 5, "n" # error: 31, "n"
+with trio.open_nursery() as n, trio.open_nursery() as n:  # error: 5, "n", "nursery" # error: 31, "n", "nursery"
     n.start(...)
 
 # safe if passing variable as parameter
@@ -83,7 +83,7 @@ with trio.open_nursery() as n:
 
 # body is a call to await n.start
 async def foo_1():
-    with trio.open_nursery(...) as n:  # error: 9, "n"
+    with trio.open_nursery(...) as n:  # error: 9, "n", "nursery"
         await n.start(...)
 
 

--- a/tests/eval_files/async112_anyio.py
+++ b/tests/eval_files/async112_anyio.py
@@ -11,13 +11,13 @@ async def bar(*args): ...
 
 
 async def foo():
-    async with anyio.create_task_group() as tg:  # error: 15, "tg"
+    async with anyio.create_task_group() as tg:  # error: 15, "tg", "taskgroup"
         await tg.start_soon(bar())
 
     async with anyio.create_task_group() as tg:
         await tg.start(bar(tg))
 
-    async with anyio.create_task_group() as tg:  # error: 15, "tg"
+    async with anyio.create_task_group() as tg:  # error: 15, "tg", "taskgroup"
         tg.start_soon(bar())
 
     async with anyio.create_task_group() as tg:

--- a/tests/eval_files/async112_asyncio.py
+++ b/tests/eval_files/async112_asyncio.py
@@ -13,7 +13,7 @@ async def bar(*args): ...
 
 
 async def foo():
-    async with asyncio.TaskGroup() as tg:  # error: 15, "tg"
+    async with asyncio.TaskGroup() as tg:  # error: 15, "tg", "taskgroup"
         tg.create_task(bar())
 
     async with asyncio.TaskGroup() as tg:

--- a/tests/eval_files/async113.py
+++ b/tests/eval_files/async113.py
@@ -1,4 +1,6 @@
 # mypy: disable-error-code="arg-type,attr-defined"
+# ARG --startable-in-context-manager=my_startable
+from __future__ import annotations
 from contextlib import asynccontextmanager
 
 import anyio
@@ -22,6 +24,84 @@ async def foo():
     boo.start_soon(trio.run_process)  # ASYNC113: 4
 
     boo_anyio: anyio.TaskGroup = ...  # type: ignore
+    # false alarm - anyio.run_process is not startable
+    # (nor is asyncio.run_process)
     boo_anyio.start_soon(anyio.run_process)  # ASYNC113: 4
 
     yield
+
+
+async def my_startable(task_status: trio.TaskStatus[object] = trio.TASK_STATUS_IGNORED):
+    task_status.started()
+    await trio.lowlevel.checkpoint()
+
+
+# name of variable being [xxx.]nursery triggers it
+class MyCm_named_variable:
+    def __init__(self):
+        self.nursery_manager = trio.open_nursery()
+        self.nursery = None
+
+    async def __aenter__(self):
+        self.nursery = await self.nursery_manager.__aenter__()
+        self.nursery.start_soon(my_startable)  # ASYNC113: 8
+
+    async def __aexit__(self, *args):
+        assert self.nursery is not None
+        await self.nursery_manager.__aexit__(*args)
+
+
+# call chain is not tracked
+# trio.open_nursery -> NurseryManager
+# NurseryManager.__aenter__ -> nursery
+class MyCm_calls:
+    async def __aenter__(self):
+        self.nursery_manager = trio.open_nursery()
+        self.moo = None
+        self.moo = await self.nursery_manager.__aenter__()
+        self.moo.start_soon(my_startable)
+
+    async def __aexit__(self, *args):
+        assert self.moo is not None
+        await self.nursery_manager.__aexit__(*args)
+
+
+# types of class variables are not tracked across functions
+class MyCm_typehint_class_variable:
+    def __init__(self):
+        self.nursery_manager = trio.open_nursery()
+        self.moo: trio.Nursery = None  # type: ignore
+
+    async def __aenter__(self):
+        self.moo = await self.nursery_manager.__aenter__()
+        self.moo.start_soon(my_startable)
+
+    async def __aexit__(self, *args):
+        assert self.moo is not None
+        await self.nursery_manager.__aexit__(*args)
+
+
+# type hint with __or__ is not picked up
+class MyCm_typehint:
+    async def __aenter__(self):
+        self.nursery_manager = trio.open_nursery()
+        self.moo: trio.Nursery | None = None
+        self.moo = await self.nursery_manager.__aenter__()
+        self.moo.start_soon(my_startable)
+
+    async def __aexit__(self, *args):
+        assert self.moo is not None
+        await self.nursery_manager.__aexit__(*args)
+
+
+# only if the type hint is exactly trio.Nursery
+class MyCm_typehint_explicit:
+    async def __aenter__(self):
+        self.nursery_manager = trio.open_nursery()
+        self.moo: trio.Nursery = None  # type: ignore
+        self.moo = await self.nursery_manager.__aenter__()
+        self.moo.start_soon(my_startable)  # ASYNC113: 8
+
+    async def __aexit__(self, *args):
+        assert self.moo is not None
+        await self.nursery_manager.__aexit__(*args)

--- a/tests/eval_files/async113_anyio.py
+++ b/tests/eval_files/async113_anyio.py
@@ -1,12 +1,22 @@
 # mypy: disable-error-code="arg-type"
+# ARG --startable-in-context-manager=my_startable
 from contextlib import asynccontextmanager
 
 import anyio
+
+
+async def my_startable(
+    task_status: anyio.abc.TaskStatus[object] = anyio.TASK_STATUS_IGNORED,
+):
+    task_status.started()
+    await anyio.lowlevel.checkpoint()
 
 
 @asynccontextmanager
 async def foo():
     # create_task_group only exists in anyio
     async with anyio.create_task_group() as bar_tg:
+        bar_tg.start_soon(my_startable)  # ASYNC113: 8
+        # false alarm - anyio.run_process is not startable
         bar_tg.start_soon(anyio.run_process)  # ASYNC113: 8
-    yield
+        yield

--- a/tests/eval_files/async113_asyncio.py
+++ b/tests/eval_files/async113_asyncio.py
@@ -1,0 +1,17 @@
+# BASE_LIBRARY asyncio
+# ARG --startable-in-context-manager=bar
+# TRIO_NO_ERROR
+# ANYIO_NO_ERROR
+
+from contextlib import asynccontextmanager
+import asyncio
+
+
+async def bar(): ...
+
+
+@asynccontextmanager
+async def my_cm():
+    async with asyncio.TaskGroup() as tg:  # type: ignore[attr-defined]
+        tg.create_task(bar)  # ASYNC113: 8
+        yield

--- a/tests/test_flake8_async.py
+++ b/tests/test_flake8_async.py
@@ -308,7 +308,9 @@ def test_eval(
     )
 
     if only_check_not_crash:
-        return
+        # mark it as skipped to indicate we didn't actually test anything in particular
+        # (it confused me once when I didn't notice a file was marked with NOTRIO)
+        pytest.skip()
 
     # Check that error messages refer to current library, or to no library.
     if test not in (

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,9 @@ deps =
     hypothesmith >= 0.3.3
     trio
 commands =
-    pytest {posargs:-n auto}
+    coverage erase
+    coverage run -m pytest {posargs:-n auto}
+    coverage html
 
 [testenv:docs]
 description = Generate docs locally
@@ -34,12 +36,6 @@ commands =
 
 # Settings for other tools
 [pytest]
-addopts =
-    --tb=native
-    --cov=flake8_async
-    --cov-branch
-    --cov-report=term-missing:skip-covered
-    --cov-fail-under=100
 filterwarnings =
     error
 

--- a/tox.ini
+++ b/tox.ini
@@ -18,9 +18,7 @@ deps =
     hypothesmith >= 0.3.3
     trio
 commands =
-    coverage erase
-    coverage run -m pytest {posargs:-n auto}
-    coverage html
+    pytest {posargs:-n auto}
 
 [testenv:docs]
 description = Generate docs locally
@@ -36,6 +34,12 @@ commands =
 
 # Settings for other tools
 [pytest]
+addopts =
+    --tb=native
+    --cov=flake8_async
+    --cov-branch
+    --cov-report=term-missing:skip-covered
+    --cov-fail-under=100
 filterwarnings =
     error
 


### PR DESCRIPTION
Various small fixes I noticed while going through code/doc/issues.

* doc updates to 113 and `startable-in-context-manager`
* ASYNC102 await-in-finally-or-cancelled no longer treats `open_nursery` as a cancel scope.
  * While you can make the cancelscope inside the nursery shielded with a timeout, that was never actually supported (there was no logic for seeing `nursery.cancelscope.shield = True`, only for `nursery.shield = True`, which is not possible)
  * `open_nursery` is itself an async function so you can't safely open a nursery anyway.
*  async112 error message now specifies if it's a nursery or taskgroup.
   * for dumb reasons I confused myself into thinking async111 & async112 didn't have asyncio support, and fully rewrote that from scratch :upside_down_face: But some of the stuff was better so I kept it after noticing my mistake and rebasing onto an updated main.