### PR TITLE
add async121 control-flow-in-taskgroup

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 
 *[CalVer, YY.month.patch](https://calver.org/)*
 
-24.8.2
+24.9.1
 ======
 - Add :ref:`ASYNC121 <async121>` control-flow-in-taskgroup
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 
 *[CalVer, YY.month.patch](https://calver.org/)*
 
-24.8.1
+24.8.2
 ======
 - Add :ref:`ASYNC121 <async121>` control-flow-in-taskgroup
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,10 @@ Changelog
 
 24.8.1
 ======
+- Add :ref:`ASYNC121 <async121>` control-flow-in-taskgroup
+
+24.8.1
+======
 - Add config option ``transform-async-generator-decorators``, to list decorators which
   suppress :ref:`ASYNC900 <async900>`.
 

--- a/docs/rules.rst
+++ b/docs/rules.rst
@@ -84,7 +84,7 @@ _`ASYNC120` : await-in-except
     This is currently not able to detect asyncio shields.
 
 _`ASYNC121`: control-flow-in-taskgroup
-    `return`, `continue`, and `break` inside a :ref:`taskgroup_nursery` can lead to counterintuitive behaviour. Refactor the code to instead cancel the :ref:`cancel_scope` and place the statement outside of the TaskGroup/Nursery block. See `trio#1493 <https://github.com/python-trio/trio/issues/1493>`.
+    `return`, `continue`, and `break` inside a :ref:`taskgroup_nursery` can lead to counterintuitive behaviour. Refactor the code to instead cancel the :ref:`cancel_scope` inside the TaskGroup/Nursery and place the statement outside of the TaskGroup/Nursery block. See `Trio issue #1493 <https://github.com/python-trio/trio/issues/1493>`.
 
 
 Blocking sync calls in async functions

--- a/docs/rules.rst
+++ b/docs/rules.rst
@@ -83,6 +83,9 @@ _`ASYNC120` : await-in-except
     This will not trigger when :ref:`ASYNC102 <ASYNC102>` does, and if you don't care about losing non-cancelled exceptions you could disable this rule.
     This is currently not able to detect asyncio shields.
 
+_`ASYNC121`: control-flow-in-taskgroup
+    `return`, `continue`, and `break` inside a :ref:`taskgroup_nursery` can lead to counterintuitive behaviour. Refactor the code to instead cancel the :ref:`cancel_scope` and place the statement outside of the TaskGroup/Nursery block. See `trio#1493 <https://github.com/python-trio/trio/issues/1493>`.
+
 
 Blocking sync calls in async functions
 ======================================

--- a/docs/rules.rst
+++ b/docs/rules.rst
@@ -84,7 +84,7 @@ _`ASYNC120` : await-in-except
     This is currently not able to detect asyncio shields.
 
 _`ASYNC121`: control-flow-in-taskgroup
-    `return`, `continue`, and `break` inside a :ref:`taskgroup_nursery` can lead to counterintuitive behaviour. Refactor the code to instead cancel the :ref:`cancel_scope` inside the TaskGroup/Nursery and place the statement outside of the TaskGroup/Nursery block. See `Trio issue #1493 <https://github.com/python-trio/trio/issues/1493>`.
+    `return`, `continue`, and `break` inside a :ref:`taskgroup_nursery` can lead to counterintuitive behaviour. Refactor the code to instead cancel the :ref:`cancel_scope` inside the TaskGroup/Nursery and place the statement outside of the TaskGroup/Nursery block. In asyncio a user might expect the statement to have an immediate effect, but it will wait for all tasks to finish before having an effect. See `Trio issue #1493 <https://github.com/python-trio/trio/issues/1493>` for further issues specific to trio/anyio.
 
 
 Blocking sync calls in async functions

--- a/flake8_async/__init__.py
+++ b/flake8_async/__init__.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
 
 
 # CalVer: YY.month.patch, e.g. first release of July 2022 == "22.7.1"
-__version__ = "24.8.1"
+__version__ = "24.8.2"
 
 
 # taken from https://github.com/Zac-HD/shed

--- a/flake8_async/__init__.py
+++ b/flake8_async/__init__.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
 
 
 # CalVer: YY.month.patch, e.g. first release of July 2022 == "22.7.1"
-__version__ = "24.8.2"
+__version__ = "24.9.1"
 
 
 # taken from https://github.com/Zac-HD/shed

--- a/flake8_async/visitors/visitors.py
+++ b/flake8_async/visitors/visitors.py
@@ -374,11 +374,12 @@ class Visitor121(Flake8AsyncVisitor):
             ) or get_matching_call(item.context_expr, "TaskGroup", base="asyncio"):
                 self.unsafe_stack.append("task group")
 
-    def visit_While(self, node: ast.While | ast.For):
+    def visit_While(self, node: ast.While | ast.For | ast.AsyncFor):
         self.save_state(node, "unsafe_stack", copy=True)
         self.unsafe_stack.append("loop")
 
     visit_For = visit_While
+    visit_AsyncFor = visit_While
 
     def check_loop_flow(self, node: ast.Continue | ast.Break, statement: str) -> None:
         # self.unsafe_stack should never be empty, but no reason not to avoid a crash

--- a/flake8_async/visitors/visitors.py
+++ b/flake8_async/visitors/visitors.py
@@ -371,7 +371,7 @@ class Visitor121(Flake8AsyncVisitor):
                 self.unsafe_stack.append("nursery")
             elif get_matching_call(
                 item.context_expr, "create_task_group", base="anyio"
-            ):
+            ) or get_matching_call(item.context_expr, "TaskGroup", base="asyncio"):
                 self.unsafe_stack.append("task group")
 
     def visit_While(self, node: ast.While | ast.For):

--- a/tests/eval_files/async121.py
+++ b/tests/eval_files/async121.py
@@ -1,0 +1,66 @@
+# ASYNCIO_NO_ERROR # not a problem in asyncio
+# ANYIO_NO_ERROR # checked in async121_anyio.py
+
+import trio
+
+
+async def foo_return():
+    async with trio.open_nursery():
+        return  # ASYNC121: 8, "return", "nursery"
+
+
+async def foo_return_nested():
+    async with trio.open_nursery():
+
+        def bar():
+            return  # safe
+
+
+# continue
+async def foo_while_continue_safe():
+    async with trio.open_nursery():
+        while True:
+            continue  # safe
+
+
+async def foo_while_continue_unsafe():
+    while True:
+        async with trio.open_nursery():
+            continue  # ASYNC121: 12, "continue", "nursery"
+
+
+async def foo_for_continue_safe():
+    async with trio.open_nursery():
+        for _ in range(5):
+            continue  # safe
+
+
+async def foo_for_continue_unsafe():
+    for _ in range(5):
+        async with trio.open_nursery():
+            continue  # ASYNC121: 12, "continue", "nursery"
+
+
+# break
+async def foo_while_break_safe():
+    async with trio.open_nursery():
+        while True:
+            break  # safe
+
+
+async def foo_while_break_unsafe():
+    while True:
+        async with trio.open_nursery():
+            break  # ASYNC121: 12, "break", "nursery"
+
+
+async def foo_for_break_safe():
+    async with trio.open_nursery():
+        for _ in range(5):
+            break  # safe
+
+
+async def foo_for_break_unsafe():
+    for _ in range(5):
+        async with trio.open_nursery():
+            break  # ASYNC121: 12, "break", "nursery"

--- a/tests/eval_files/async121_anyio.py
+++ b/tests/eval_files/async121_anyio.py
@@ -5,63 +5,18 @@
 import anyio
 
 
+# To avoid mypy unreachable-statement we wrap control flow calls in if statements
+# they should have zero effect on the visitor logic.
+def condition() -> bool:
+    return False
+
+
+# only tests that asyncio.TaskGroup is detected, main tests in async121.py
 async def foo_return():
-    async with anyio.create_task_group():
-        return  # ASYNC121: 8, "return", "task group"
-
-
-async def foo_return_nested():
-    async with anyio.create_task_group():
-
-        def bar():
-            return  # safe
-
-
-# continue
-async def foo_while_continue_safe():
-    async with anyio.create_task_group():
-        while True:
-            continue  # safe
-
-
-async def foo_while_continue_unsafe():
     while True:
         async with anyio.create_task_group():
-            continue  # ASYNC121: 12, "continue", "task group"
-
-
-async def foo_for_continue_safe():
-    async with anyio.create_task_group():
-        for _ in range(5):
-            continue  # safe
-
-
-async def foo_for_continue_unsafe():
-    for _ in range(5):
-        async with anyio.create_task_group():
-            continue  # ASYNC121: 12, "continue", "task group"
-
-
-# break
-async def foo_while_break_safe():
-    async with anyio.create_task_group():
-        while True:
-            break  # safe
-
-
-async def foo_while_break_unsafe():
-    while True:
-        async with anyio.create_task_group():
-            break  # ASYNC121: 12, "break", "task group"
-
-
-async def foo_for_break_safe():
-    async with anyio.create_task_group():
-        for _ in range(5):
-            break  # safe
-
-
-async def foo_for_break_unsafe():
-    for _ in range(5):
-        async with anyio.create_task_group():
-            break  # ASYNC121: 12, "break", "task group"
+            if condition():
+                continue  # ASYNC121: 16, "continue", "task group"
+            if condition():
+                break  # ASYNC121: 16, "break", "task group"
+            return  # ASYNC121: 12, "return", "task group"

--- a/tests/eval_files/async121_anyio.py
+++ b/tests/eval_files/async121_anyio.py
@@ -1,0 +1,67 @@
+# ASYNCIO_NO_ERROR # not a problem in asyncio
+# TRIO_NO_ERROR # checked in async121.py
+# BASE_LIBRARY anyio
+
+import anyio
+
+
+async def foo_return():
+    async with anyio.create_task_group():
+        return  # ASYNC121: 8, "return", "task group"
+
+
+async def foo_return_nested():
+    async with anyio.create_task_group():
+
+        def bar():
+            return  # safe
+
+
+# continue
+async def foo_while_continue_safe():
+    async with anyio.create_task_group():
+        while True:
+            continue  # safe
+
+
+async def foo_while_continue_unsafe():
+    while True:
+        async with anyio.create_task_group():
+            continue  # ASYNC121: 12, "continue", "task group"
+
+
+async def foo_for_continue_safe():
+    async with anyio.create_task_group():
+        for _ in range(5):
+            continue  # safe
+
+
+async def foo_for_continue_unsafe():
+    for _ in range(5):
+        async with anyio.create_task_group():
+            continue  # ASYNC121: 12, "continue", "task group"
+
+
+# break
+async def foo_while_break_safe():
+    async with anyio.create_task_group():
+        while True:
+            break  # safe
+
+
+async def foo_while_break_unsafe():
+    while True:
+        async with anyio.create_task_group():
+            break  # ASYNC121: 12, "break", "task group"
+
+
+async def foo_for_break_safe():
+    async with anyio.create_task_group():
+        for _ in range(5):
+            break  # safe
+
+
+async def foo_for_break_unsafe():
+    for _ in range(5):
+        async with anyio.create_task_group():
+            break  # ASYNC121: 12, "break", "task group"

--- a/tests/eval_files/async121_asyncio.py
+++ b/tests/eval_files/async121_asyncio.py
@@ -7,63 +7,18 @@
 import asyncio
 
 
+# To avoid mypy unreachable-statement we wrap control flow calls in if statements
+# they should have zero effect on the visitor logic.
+def condition() -> bool:
+    return False
+
+
+# only tests that asyncio.TaskGroup is detected, main tests in async121.py
 async def foo_return():
-    async with asyncio.TaskGroup():
-        return  # ASYNC121: 8, "return", "task group"
-
-
-async def foo_return_nested():
-    async with asyncio.TaskGroup():
-
-        def bar():
-            return  # safe
-
-
-# continue
-async def foo_while_continue_safe():
-    async with asyncio.TaskGroup():
-        while True:
-            continue  # safe
-
-
-async def foo_while_continue_unsafe():
     while True:
         async with asyncio.TaskGroup():
-            continue  # ASYNC121: 12, "continue", "task group"
-
-
-async def foo_for_continue_safe():
-    async with asyncio.TaskGroup():
-        for _ in range(5):
-            continue  # safe
-
-
-async def foo_for_continue_unsafe():
-    for _ in range(5):
-        async with asyncio.TaskGroup():
-            continue  # ASYNC121: 12, "continue", "task group"
-
-
-# break
-async def foo_while_break_safe():
-    async with asyncio.TaskGroup():
-        while True:
-            break  # safe
-
-
-async def foo_while_break_unsafe():
-    while True:
-        async with asyncio.TaskGroup():
-            break  # ASYNC121: 12, "break", "task group"
-
-
-async def foo_for_break_safe():
-    async with asyncio.TaskGroup():
-        for _ in range(5):
-            break  # safe
-
-
-async def foo_for_break_unsafe():
-    for _ in range(5):
-        async with asyncio.TaskGroup():
-            break  # ASYNC121: 12, "break", "task group"
+            if condition():
+                continue  # ASYNC121: 16, "continue", "task group"
+            if condition():
+                break  # ASYNC121: 16, "break", "task group"
+            return  # ASYNC121: 12, "return", "task group"

--- a/tests/eval_files/async121_asyncio.py
+++ b/tests/eval_files/async121_asyncio.py
@@ -1,17 +1,19 @@
-# ASYNCIO_NO_ERROR # checked in async121_asyncio.py
+# ANYIO_NO_ERROR
 # TRIO_NO_ERROR # checked in async121.py
-# BASE_LIBRARY anyio
+# BASE_LIBRARY asyncio
+# TaskGroup was added in 3.11, we run type checking with 3.9
+# mypy: disable-error-code=attr-defined
 
-import anyio
+import asyncio
 
 
 async def foo_return():
-    async with anyio.create_task_group():
+    async with asyncio.TaskGroup():
         return  # ASYNC121: 8, "return", "task group"
 
 
 async def foo_return_nested():
-    async with anyio.create_task_group():
+    async with asyncio.TaskGroup():
 
         def bar():
             return  # safe
@@ -19,49 +21,49 @@ async def foo_return_nested():
 
 # continue
 async def foo_while_continue_safe():
-    async with anyio.create_task_group():
+    async with asyncio.TaskGroup():
         while True:
             continue  # safe
 
 
 async def foo_while_continue_unsafe():
     while True:
-        async with anyio.create_task_group():
+        async with asyncio.TaskGroup():
             continue  # ASYNC121: 12, "continue", "task group"
 
 
 async def foo_for_continue_safe():
-    async with anyio.create_task_group():
+    async with asyncio.TaskGroup():
         for _ in range(5):
             continue  # safe
 
 
 async def foo_for_continue_unsafe():
     for _ in range(5):
-        async with anyio.create_task_group():
+        async with asyncio.TaskGroup():
             continue  # ASYNC121: 12, "continue", "task group"
 
 
 # break
 async def foo_while_break_safe():
-    async with anyio.create_task_group():
+    async with asyncio.TaskGroup():
         while True:
             break  # safe
 
 
 async def foo_while_break_unsafe():
     while True:
-        async with anyio.create_task_group():
+        async with asyncio.TaskGroup():
             break  # ASYNC121: 12, "break", "task group"
 
 
 async def foo_for_break_safe():
-    async with anyio.create_task_group():
+    async with asyncio.TaskGroup():
         for _ in range(5):
             break  # safe
 
 
 async def foo_for_break_unsafe():
     for _ in range(5):
-        async with anyio.create_task_group():
+        async with asyncio.TaskGroup():
             break  # ASYNC121: 12, "break", "task group"

--- a/tests/test_flake8_async.py
+++ b/tests/test_flake8_async.py
@@ -478,6 +478,9 @@ error_codes_ignored_when_checking_transformed_sync_code = {
     "ASYNC116",
     "ASYNC117",
     "ASYNC118",
+    # opening nurseries & taskgroups can only be done in async context, so ASYNC121
+    # doesn't check for it
+    "ASYNC121",
     "ASYNC300",
     "ASYNC912",
 }


### PR DESCRIPTION
closes #261 

Not sure whether to name the rule `control-flow-in-taskgroup`, `control-flow-in-nursery`, or `control-flow-in-taskgroup-or-nursery`. All previous nursery/taskgroup-related rules have in fact been about the cancelscope within them, such that none of them had to decide.
This made me want to double-check that this rule *is* exclusive to nursery/taskgroups, and that the rule shouldn't be expanded to also trigger on control flows inside cancelscopes, but I cannot personally come up with anything at least.

The test isn't *fully* exhaustive with nested loops and stuff, but the visitor is simple enough I think it's unlikely something would sneak through.