### PR TITLE
ASYNC113 & ASYNC121 false alarm with nested sync functions

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,11 @@ Changelog
 
 `CalVer, YY.month.patch <https://calver.org/>`_
 
+24.9.2
+======
+- Fix false alarm in :ref:`ASYNC113 <async113>` and :ref:`ASYNC121 <async121>` with sync functions nested inside an async function.
+
+
 24.9.1
 ======
 - Add :ref:`ASYNC121 <async121>` control-flow-in-taskgroup

--- a/flake8_async/__init__.py
+++ b/flake8_async/__init__.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
 
 
 # CalVer: YY.month.patch, e.g. first release of July 2022 == "22.7.1"
-__version__ = "24.9.1"
+__version__ = "24.9.2"
 
 
 # taken from https://github.com/Zac-HD/shed

--- a/flake8_async/visitors/visitors.py
+++ b/flake8_async/visitors/visitors.py
@@ -188,6 +188,11 @@ class Visitor113(Flake8AsyncVisitor):
             node, "asynccontextmanager"
         )
 
+    def visit_FunctionDef(self, node: ast.FunctionDef):
+        self.save_state(node, "aenter")
+        # sync function should never be named __aenter__ or have @asynccontextmanager
+        self.aenter = False
+
     def visit_Yield(self, node: ast.Yield):
         self.aenter = False
 

--- a/flake8_async/visitors/visitors.py
+++ b/flake8_async/visitors/visitors.py
@@ -398,9 +398,11 @@ class Visitor121(Flake8AsyncVisitor):
             if unsafe_cm in self.unsafe_stack:
                 self.error(node, "return", unsafe_cm)
 
-    def visit_FunctionDef(self, node: ast.FunctionDef):
+    def visit_FunctionDef(self, node: ast.FunctionDef | ast.AsyncFunctionDef):
         self.save_state(node, "unsafe_stack", copy=True)
         self.unsafe_stack = []
+
+    visit_AsyncFunctionDef = visit_FunctionDef
 
 
 @error_class_cst

--- a/tests/eval_files/async113.py
+++ b/tests/eval_files/async113.py
@@ -105,3 +105,11 @@ class MyCm_typehint_explicit:
     async def __aexit__(self, *args):
         assert self.moo is not None
         await self.nursery_manager.__aexit__(*args)
+
+@asynccontextmanager
+async def foo():
+    with trio.open_nursery() as bar:
+        def non_async_func():
+            bar.start_soon(trio.run_process)
+
+        yield

--- a/tests/eval_files/async113.py
+++ b/tests/eval_files/async113.py
@@ -106,9 +106,11 @@ class MyCm_typehint_explicit:
         assert self.moo is not None
         await self.nursery_manager.__aexit__(*args)
 
+
 @asynccontextmanager
-async def foo():
+async def foo_nested_sync_def():
     with trio.open_nursery() as bar:
+
         def non_async_func():
             bar.start_soon(trio.run_process)
 

--- a/tests/eval_files/async121.py
+++ b/tests/eval_files/async121.py
@@ -29,6 +29,8 @@ async def foo_return_nested():
 
         def bar():
             return  # safe
+        async def bar():
+            return  # safe
 
 
 async def foo_while_safe():

--- a/tests/eval_files/async121.py
+++ b/tests/eval_files/async121.py
@@ -29,6 +29,7 @@ async def foo_return_nested():
 
         def bar():
             return  # safe
+
         async def bar():
             return  # safe
 


### PR DESCRIPTION
Fixes #286 

I also did a search for `visit_FunctionDef` and `visit_AsyncFunctionDef` in the codebase and caught the same error for async113 (though it should very rarely occur for 113). At first glance a couple other visitors had the same problem, until I noticed those were cst visitors (which instead has an `asynchronous` attribute).

For 113 we could consider having the logic for `visit_FunctionDef` being the same as `visit_AsyncFunctionDef` instead of always setting `self.aenter = False` in case users are transforming sync methods to async methods, but given such exotic stuff we're maybe better off staying away and avoiding super obscure false positives.

We could consider adding a test that checks if any AST visitors only has one of the visitors defined, and could do the same for `With`/`AsyncWith` and `For`/`AsyncFor` (the latter which was in fact only caught in code review for #282). It will have a decent false-positive ratio though, but not very troublesome to have an ignore list or declare dummy methods.


Another approach is preferring cst over AST, and I've been inconsistent when creating new visitors despite https://github.com/python-trio/flake8-async/issues/124. I should try and compile pros/cons and write a comment over there.