### PR TITLE
fix various issues with ASYNC102

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,14 @@ Changelog
 
 `CalVer, YY.month.patch <https://calver.org/>`_
 
+24.9.3
+======
+- :ref:`ASYNC102 <async102>`:
+  - handles nested cancel scopes
+  - detects internal cancel scopes of nurseries as a way to shield&deadline
+  - no longer treats :func:`trio.open_nursery` or :func:`anyio.create_task_group` as cancellation sources
+  - handles the `shield` parameter to :func:`trio.fail_after` and friends (added in trio 0.27)
+
 24.9.2
 ======
 - Fix false alarm in :ref:`ASYNC113 <async113>` and :ref:`ASYNC121 <async121>` with sync functions nested inside an async function.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,7 +6,7 @@ Changelog
 
 24.9.3
 ======
-- :ref:`ASYNC102 <async102>`:
+- :ref:`ASYNC102 <async102>` and :ref:`ASYNC120 <async120>`:
   - handles nested cancel scopes
   - detects internal cancel scopes of nurseries as a way to shield&deadline
   - no longer treats :func:`trio.open_nursery` or :func:`anyio.create_task_group` as cancellation sources

--- a/flake8_async/__init__.py
+++ b/flake8_async/__init__.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
 
 
 # CalVer: YY.month.patch, e.g. first release of July 2022 == "22.7.1"
-__version__ = "24.9.2"
+__version__ = "24.9.3"
 
 
 # taken from https://github.com/Zac-HD/shed

--- a/tests/eval_files/async102_anyio.py
+++ b/tests/eval_files/async102_anyio.py
@@ -72,3 +72,16 @@ async def foo_anyio_shielded():
             await foo()  # safe
     except BaseException:
         await foo()  # safe
+
+
+# anyio.create_task_group is not a source of cancellations
+async def foo_open_nursery_no_cancel():
+    try:
+        pass
+    finally:
+        # create_task_group does not block/checkpoint on entry, and is not
+        # a cancellation point on exit.
+        async with anyio.create_task_group() as tg:
+            tg.cancel_scope.deadline = anyio.current_time() + 10
+            tg.cancel_scope.shield = True
+            await foo()

--- a/tests/eval_files/async102_asyncio.py
+++ b/tests/eval_files/async102_asyncio.py
@@ -37,3 +37,12 @@ async def foo():
         await asyncio.shield(  # error: 8, Statement("try/finally", lineno-3)
             asyncio.wait_for(foo())
         )
+
+
+# asyncio.TaskGroup *is* a source of cancellations (on exit)
+async def foo_open_nursery_no_cancel():
+    try:
+        pass
+    finally:
+        async with asyncio.TaskGroup() as tg:  # error: 8, Statement("try/finally", lineno-3)
+            ...

--- a/tests/eval_files/async102_trio.py
+++ b/tests/eval_files/async102_trio.py
@@ -31,3 +31,16 @@ async def foo5():
             await foo()  # safe
     except BaseException:
         await foo()  # safe, since after trio.Cancelled
+
+
+# trio.open_nursery is not a source of cancellations
+async def foo_open_nursery_no_cancel():
+    try:
+        pass
+    finally:
+        # open_nursery does not block/checkpoint on entry, and is not
+        # a cancellation point on exit.
+        async with trio.open_nursery() as nursery:
+            nursery.cancel_scope.deadline = trio.current_time() + 10
+            nursery.cancel_scope.shield = True
+            await foo()


### PR DESCRIPTION
Fixes most of #283 and some other things I noticed, only remaining thing being checking other rules for if they should also have special handling of `open_nursery`/`create_task_group`.

Note that `trio.move_on_after(shield=True)` has not been released yet