### PR TITLE
add ASYNC122 delayed-entry-of-relative-cancelscope

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,10 @@ Changelog
 
 `CalVer, YY.month.patch <https://calver.org/>`_
 
+24.9.4
+======
+- Add :ref:`ASYNC122 <async122>` delayed-entry-of-relative-cancelscope.
+
 24.9.3
 ======
 - :ref:`ASYNC102 <async102>` and :ref:`ASYNC120 <async120>`:
@@ -19,7 +23,7 @@ Changelog
 
 24.9.1
 ======
-- Add :ref:`ASYNC121 <async121>` control-flow-in-taskgroup
+- Add :ref:`ASYNC121 <async121>` control-flow-in-taskgroup.
 
 24.8.1
 ======
@@ -37,7 +41,7 @@ Changelog
 
 24.5.5
 ======
-- Add :ref:`ASYNC300 <async300>` create-task-no-reference
+- Add :ref:`ASYNC300 <async300>` create-task-no-reference.
 
 24.5.4
 ======

--- a/docs/rules.rst
+++ b/docs/rules.rst
@@ -86,6 +86,8 @@ _`ASYNC120` : await-in-except
 _`ASYNC121`: control-flow-in-taskgroup
     `return`, `continue`, and `break` inside a :ref:`taskgroup_nursery` can lead to counterintuitive behaviour. Refactor the code to instead cancel the :ref:`cancel_scope` inside the TaskGroup/Nursery and place the statement outside of the TaskGroup/Nursery block. In asyncio a user might expect the statement to have an immediate effect, but it will wait for all tasks to finish before having an effect. See `Trio issue #1493 <https://github.com/python-trio/trio/issues/1493>`_ for further issues specific to trio/anyio.
 
+_`ASYNC122`: delayed-entry-of-relative-cancelscope
+    :func:`trio.move_on_after`, :func:`trio.fail_after`, :func:`anyio.move_on_after` and :func:`anyio.fail_after` behaves unintuitively if initialization and entry are separated, with the timeout starting on initialization. Trio>=0.27 changes this behaviour, so if you don't support older versions you should disable this check. See `Trio issue #2512 <https://github.com/python-trio/trio/issues/2512>`_.
 
 Blocking sync calls in async functions
 ======================================

--- a/flake8_async/__init__.py
+++ b/flake8_async/__init__.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
 
 
 # CalVer: YY.month.patch, e.g. first release of July 2022 == "22.7.1"
-__version__ = "24.9.3"
+__version__ = "24.9.4"
 
 
 # taken from https://github.com/Zac-HD/shed

--- a/tests/eval_files/async122.py
+++ b/tests/eval_files/async122.py
@@ -1,0 +1,35 @@
+# ASYNCIO_NO_ERROR
+
+import trio
+
+
+def safe():
+    with trio.move_on_after(5):
+        ...
+    with open("hello"), trio.move_on_after(5):
+        ...
+
+
+def separated():
+    k = trio.move_on_after(5)  # ASYNC122: 8, "trio.move_on_after"
+
+    with k:
+        ...
+
+    l = trio.fail_after(5)  # ASYNC122: 8, "trio.fail_after"
+    with l:
+        ...
+
+
+def fancy_thing_we_dont_cover():
+    # it's hard to distinguish this bad case
+    kk = trio.fail_after
+
+    ll = kk(5)
+
+    with ll:
+        ...
+    # from this good case
+    with kk(5):
+        ...
+    # so we don't bother

--- a/tests/test_flake8_async.py
+++ b/tests/test_flake8_async.py
@@ -481,6 +481,7 @@ error_codes_ignored_when_checking_transformed_sync_code = {
     # opening nurseries & taskgroups can only be done in async context, so ASYNC121
     # doesn't check for it
     "ASYNC121",
+    "ASYNC122",
     "ASYNC300",
     "ASYNC912",
 }


### PR DESCRIPTION
fixes #290 

It doesn't handle the complex case of
```python
foo = trio.fail_after
bar = foo(5)
trio.sleep(3)
with bar:
  ...
```
and while it would be possible to error anytime somebody refers to `trio.fail_after` not directly inside a `with` call it'd probably mostly just lead to unnecessary false positives.