### PR TITLE
fix assertionerror with infinite loop in context manager

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,10 @@ Changelog
 
 `CalVer, YY.month.patch <https://calver.org/>`_
 
+24.9.5
+======
+- Fix crash when analyzing code with infinite loop inside context manager.
+
 24.9.4
 ======
 - Add :ref:`ASYNC122 <async122>` delayed-entry-of-relative-cancelscope.

--- a/flake8_async/__init__.py
+++ b/flake8_async/__init__.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
 
 
 # CalVer: YY.month.patch, e.g. first release of July 2022 == "22.7.1"
-__version__ = "24.9.4"
+__version__ = "24.9.5"
 
 
 # taken from https://github.com/Zac-HD/shed

--- a/flake8_async/visitors/visitor91x.py
+++ b/flake8_async/visitors/visitor91x.py
@@ -452,7 +452,7 @@ class Visitor91X(Flake8AsyncVisitor_cst, CommonVisitors):
         node: cst.Return | cst.FunctionDef | cst.Yield,
         statement: Statement,
     ) -> bool:
-        assert not isinstance(statement, ArtificialStatement)
+        assert not isinstance(statement, ArtificialStatement), statement
 
         if isinstance(node, cst.FunctionDef):
             msg = "exit"
@@ -768,7 +768,7 @@ class Visitor91X(Flake8AsyncVisitor_cst, CommonVisitors):
                 | self.uncheckpointed_statements
                 | self.loop_state.uncheckpointed_before_continue
             ):
-                if stmt == ARTIFICIAL_STATEMENT:
+                if isinstance(stmt, ArtificialStatement):
                     continue
                 any_error |= self.error_91x(err_node, stmt)
 

--- a/tests/autofix_files/async100.py
+++ b/tests/autofix_files/async100.py
@@ -121,3 +121,12 @@ async def more_nested_tests():
 async def foo():
     with trio.fail_after(1):
         yield
+
+
+# This previously caused an AssertionError, see issue #295
+async def fn(timeout):
+    with trio.fail_after(timeout):
+        while True:
+            if condition():
+                return
+            await trio.sleep(1)

--- a/tests/eval_files/async100.py
+++ b/tests/eval_files/async100.py
@@ -121,3 +121,12 @@ async def more_nested_tests():
 async def foo():
     with trio.fail_after(1):
         yield
+
+
+# This previously caused an AssertionError, see issue #295
+async def fn(timeout):
+    with trio.fail_after(timeout):
+        while True:
+            if condition():
+                return
+            await trio.sleep(1)


### PR DESCRIPTION
fixes #295 

I noticed this comment... :facepalm: 
https://github.com/python-trio/flake8-async/blob/db5317c9d9c18919390f43c56d692dd702651032/flake8_async/visitors/visitor91x.py#L43-L46