### PR TITLE
async100 now ignores trio.open_nursery and anyio.create_task_group

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,7 +5,7 @@ Changelog
 `CalVer, YY.month.patch <https://calver.org/>`_
 
 24.11.1
-======
+=======
 - :ref:`ASYNC100 <async100>` now ignores :func:`trio.open_nursery` and :func:`anyio.create_task_group` as cancellation sources.
 
 24.10.2
@@ -27,6 +27,7 @@ Changelog
 24.9.3
 ======
 - :ref:`ASYNC102 <async102>` and :ref:`ASYNC120 <async120>`:
+
   - handles nested cancel scopes
   - detects internal cancel scopes of nurseries as a way to shield&deadline
   - no longer treats :func:`trio.open_nursery` or :func:`anyio.create_task_group` as cancellation sources

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,10 @@ Changelog
 
 `CalVer, YY.month.patch <https://calver.org/>`_
 
+24.11.1
+======
+- :ref:`ASYNC100 <async100>` now ignores :func:`trio.open_nursery` and :func:`anyio.create_task_group` as cancellation sources.
+
 24.10.2
 =======
 - :ref:`ASYNC102 <async102>` now also warns about ``await()`` inside ``__aexit__``.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,7 +6,9 @@ Changelog
 
 24.11.1
 =======
-- :ref:`ASYNC100 <async100>` now ignores :func:`trio.open_nursery` and :func:`anyio.create_task_group` as cancellation sources.
+- :ref:`ASYNC100 <async100>` now ignores :func:`trio.open_nursery` and :func:`anyio.create_task_group`
+  as cancellation sources, because they are :ref:`schedule points <schedule_points>` but not
+  :ref:`cancellation points <cancel_points>`.
 
 24.10.2
 =======

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -103,7 +103,7 @@ The one exception is :func:`trio.open_nursery` and :func:`anyio.create_task_grou
 
 asyncio does not place any guarantees on if or when asyncio functions will
 checkpoint. This means that enabling and adhering to :ref:`ASYNC91x <ASYNC910>`
-will still not guarantee checkpoints.
+will still not guarantee checkpoints on asyncio.
 
 For anyio it will depend on the current backend.
 
@@ -123,7 +123,8 @@ To insert a checkpoint with no other side effects, you can use
 
 Schedule Point
 --------------
-A partial `checkpoint` that allows the async backend to switch the running task, but doesn't check for cancellation. This is available as :func:`trio.lowlevel.cancel_shielded_checkpoint`/:func:`anyio.lowlevel.cancel_shielded_checkpoint`, and equivalent to
+A schedule point is half of a full `checkpoint`, which allows the async backend to switch the running task, but doesn't check for cancellation (the other half is a `cancel_point`).
+While you are unlikely to need one, they are available as :func:`trio.lowlevel.cancel_shielded_checkpoint`/:func:`anyio.lowlevel.cancel_shielded_checkpoint`, and equivalent to
 
 .. code-block:: python
 
@@ -132,7 +133,7 @@ A partial `checkpoint` that allows the async backend to switch the running task,
    # from anyio import CancelScope, lowlevel
 
    with CancelScope(shield=True):
-       await lowlevel.checkpoint(0)
+       await lowlevel.checkpoint()
 
 asyncio does not have any direct equivalents due to their cancellation model being different.
 
@@ -142,8 +143,8 @@ asyncio does not have any direct equivalents due to their cancellation model bei
 
 Cancel Point
 ------------
-A partial `checkpoint` that will raise :ref:`cancelled` if the enclosing cancel scope has been cancelled, but does not allow the scheduler to switch to a different task.
-This is available as :func:`trio.lowlevel.checkpoint_if_cancelled`/:func:`anyio.lowlevel.checkpoint_if_cancelled`.
+A schedule point is half of a full `checkpoint`, which will raise :ref:`cancelled` if the enclosing cancel scope has been cancelled, but does not allow the scheduler to switch to a different task (the other half is a `schedule_point`).
+While you are unlikely to need one, they are available as :func:`trio.lowlevel.checkpoint_if_cancelled`/:func:`anyio.lowlevel.checkpoint_if_cancelled`.
 Users of asyncio might want to use :meth:`asyncio.Task.cancelled`.
 
 .. _channel_stream_queue:

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -103,9 +103,7 @@ The one exception is :func:`trio.open_nursery` and :func:`anyio.create_task_grou
 
 asyncio does not place any guarantees on if or when asyncio functions will
 checkpoint. This means that enabling and adhering to :ref:`ASYNC91x <ASYNC910>`
-will still not guarantee checkpoints on asyncio.
-
-For anyio it will depend on the current backend.
+will still not guarantee checkpoints on asyncio (even if used via anyio).
 
 When using Trio (or an AnyIO library that people might use on Trio), it can be
 very helpful to ensure that your own code adheres to the same guarantees as
@@ -123,7 +121,7 @@ To insert a checkpoint with no other side effects, you can use
 
 Schedule Point
 --------------
-A schedule point is half of a full `checkpoint`, which allows the async backend to switch the running task, but doesn't check for cancellation (the other half is a `cancel_point`).
+A schedule point is half of a full :ref:`checkpoint`, which allows the async backend to switch the running task, but doesn't check for cancellation (the other half is a :ref:`cancel_point`).
 While you are unlikely to need one, they are available as :func:`trio.lowlevel.cancel_shielded_checkpoint`/:func:`anyio.lowlevel.cancel_shielded_checkpoint`, and equivalent to
 
 .. code-block:: python
@@ -143,7 +141,7 @@ asyncio does not have any direct equivalents due to their cancellation model bei
 
 Cancel Point
 ------------
-A schedule point is half of a full `checkpoint`, which will raise :ref:`cancelled` if the enclosing cancel scope has been cancelled, but does not allow the scheduler to switch to a different task (the other half is a `schedule_point`).
+A schedule point is half of a full :ref:`checkpoint`, which will raise :ref:`cancelled` if the enclosing cancel scope has been cancelled, but does not allow the scheduler to switch to a different task (the other half is a :ref:`schedule_point`).
 While you are unlikely to need one, they are available as :func:`trio.lowlevel.checkpoint_if_cancelled`/:func:`anyio.lowlevel.checkpoint_if_cancelled`.
 Users of asyncio might want to use :meth:`asyncio.Task.cancelled`.
 

--- a/docs/rules.rst
+++ b/docs/rules.rst
@@ -13,6 +13,7 @@ _`ASYNC100` : cancel-scope-no-checkpoint
     A :ref:`timeout_context` does not contain any :ref:`checkpoints <checkpoint>`.
     This makes it pointless, as the timeout can only be triggered by a checkpoint.
     This check also treats ``yield`` as a checkpoint, since checkpoints can happen in the caller we yield to.
+    :func:`trio.open_nursery` and :func:`anyio.create_task_group` are excluded, as they are :ref:`schedule_points` but not :ref:`cancel_points`.
     See :ref:`ASYNC912 <async912>` which will in addition guarantee checkpoints on every code path.
 
 ASYNC101 : yield-in-cancel-scope

--- a/flake8_async/__init__.py
+++ b/flake8_async/__init__.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
 
 
 # CalVer: YY.month.patch, e.g. first release of July 2022 == "22.7.1"
-__version__ = "24.10.2"
+__version__ = "24.11.1"
 
 
 # taken from https://github.com/Zac-HD/shed

--- a/flake8_async/visitors/visitor91x.py
+++ b/flake8_async/visitors/visitor91x.py
@@ -25,6 +25,7 @@ from .helpers import (
     flatten_preserving_comments,
     fnmatch_qualified_name_cst,
     func_has_decorator,
+    identifier_to_string,
     iter_guaranteed_once_cst,
     with_has_call,
 )
@@ -491,12 +492,32 @@ class Visitor91X(Flake8AsyncVisitor_cst, CommonVisitors):
             is not None
         )
 
+    def _checkpoint_with(self, node: cst.With):
+        """Conditionally checkpoints entry/exit of With.
+
+        If the with only contains calls to open_nursery/create_task_group, it's a schedule
+        point but not a cancellation point, so we treat it as a checkpoint for async91x
+        but not for async100.
+        """
+        if getattr(node, "asynchronous", None):
+            for item in node.items:
+                if not isinstance(item.item, cst.Call):
+                    self.checkpoint()
+                    break
+                assert isinstance(item.item.func, (cst.Attribute, cst.Name))
+                func = identifier_to_string(item.item.func)
+                assert func is not None
+                if func not in ("trio.open_nursery", "anyio.create_task_group"):
+                    self.checkpoint()
+                    break
+            else:
+                self.uncheckpointed_statements = set()
+
     # Async context managers can reasonably checkpoint on either or both of entry and
     # exit.  Given that we can't tell which, we assume "both" to avoid raising a
     # missing-checkpoint warning when there might in fact be one (i.e. a false alarm).
     def visit_With_body(self, node: cst.With):
-        if getattr(node, "asynchronous", None):
-            self.checkpoint()
+        self._checkpoint_with(node)
 
         # if this might suppress exceptions, we cannot treat anything inside it as
         # checkpointing.
@@ -555,8 +576,7 @@ class Visitor91X(Flake8AsyncVisitor_cst, CommonVisitors):
             self.restore_state(original_node)
             self.uncheckpointed_statements.update(prev_checkpoints)
 
-        if getattr(original_node, "asynchronous", None):
-            self.checkpoint()
+        self._checkpoint_with(original_node)
         return updated_node
 
     # error if no checkpoint since earlier yield or function entry

--- a/flake8_async/visitors/visitor91x.py
+++ b/flake8_async/visitors/visitor91x.py
@@ -501,10 +501,12 @@ class Visitor91X(Flake8AsyncVisitor_cst, CommonVisitors):
         """
         if getattr(node, "asynchronous", None):
             for item in node.items:
-                if not isinstance(item.item, cst.Call):
+                if not isinstance(item.item, cst.Call) or not isinstance(
+                    item.item.func, (cst.Attribute, cst.Name)
+                ):
                     self.checkpoint()
                     break
-                assert isinstance(item.item.func, (cst.Attribute, cst.Name))
+
                 func = identifier_to_string(item.item.func)
                 assert func is not None
                 if func not in ("trio.open_nursery", "anyio.create_task_group"):

--- a/tests/autofix_files/async100.py
+++ b/tests/autofix_files/async100.py
@@ -136,3 +136,8 @@ async def nursery_no_cancel_point():
     # error: 9, "trio", "CancelScope"
     async with anyio.create_task_group():
         ...
+
+
+async def dont_crash_on_non_name_or_attr_call():
+    async with contextlib.asynccontextmanager(agen_fn)():
+        ...

--- a/tests/autofix_files/async100.py
+++ b/tests/autofix_files/async100.py
@@ -130,3 +130,9 @@ async def fn(timeout):
             if condition():
                 return
             await trio.sleep(1)
+
+
+async def nursery_no_cancel_point():
+    # error: 9, "trio", "CancelScope"
+    async with anyio.create_task_group():
+        ...

--- a/tests/autofix_files/async100.py.diff
+++ b/tests/autofix_files/async100.py.diff
@@ -130,7 +130,7 @@
 
      with contextlib.suppress(Exception):
          with open("blah") as file:
-@@ x,6 x,6 @@
+@@ x,9 x,9 @@
 
 
  async def nursery_no_cancel_point():
@@ -140,3 +140,6 @@
 +    # error: 9, "trio", "CancelScope"
 +    async with anyio.create_task_group():
 +        ...
+
+
+ async def dont_crash_on_non_name_or_attr_call():

--- a/tests/autofix_files/async100.py.diff
+++ b/tests/autofix_files/async100.py.diff
@@ -130,3 +130,13 @@
 
      with contextlib.suppress(Exception):
          with open("blah") as file:
+@@ x,6 x,6 @@
+
+
+ async def nursery_no_cancel_point():
+-    with trio.CancelScope():  # error: 9, "trio", "CancelScope"
+-        async with anyio.create_task_group():
+-            ...
++    # error: 9, "trio", "CancelScope"
++    async with anyio.create_task_group():
++        ...

--- a/tests/autofix_files/async100_trio.py
+++ b/tests/autofix_files/async100_trio.py
@@ -1,0 +1,10 @@
+# AUTOFIX
+# ASYNCIO_NO_ERROR # asyncio.open_nursery doesn't exist
+# ANYIO_NO_ERROR # anyio.open_nursery doesn't exist
+import trio
+
+
+async def nursery_no_cancel_point():
+    # error: 9, "trio", "CancelScope"
+    async with trio.open_nursery():
+        ...

--- a/tests/autofix_files/async100_trio.py.diff
+++ b/tests/autofix_files/async100_trio.py.diff
@@ -1,0 +1,12 @@
+---
++++
+@@ x,6 x,6 @@
+
+
+ async def nursery_no_cancel_point():
+-    with trio.CancelScope():  # error: 9, "trio", "CancelScope"
+-        async with trio.open_nursery():
+-            ...
++    # error: 9, "trio", "CancelScope"
++    async with trio.open_nursery():
++        ...

--- a/tests/eval_files/async100.py
+++ b/tests/eval_files/async100.py
@@ -130,3 +130,9 @@ async def fn(timeout):
             if condition():
                 return
             await trio.sleep(1)
+
+
+async def nursery_no_cancel_point():
+    with trio.CancelScope():  # error: 9, "trio", "CancelScope"
+        async with anyio.create_task_group():
+            ...

--- a/tests/eval_files/async100.py
+++ b/tests/eval_files/async100.py
@@ -136,3 +136,8 @@ async def nursery_no_cancel_point():
     with trio.CancelScope():  # error: 9, "trio", "CancelScope"
         async with anyio.create_task_group():
             ...
+
+
+async def dont_crash_on_non_name_or_attr_call():
+    async with contextlib.asynccontextmanager(agen_fn)():
+        ...

--- a/tests/eval_files/async100_trio.py
+++ b/tests/eval_files/async100_trio.py
@@ -1,0 +1,10 @@
+# AUTOFIX
+# ASYNCIO_NO_ERROR # asyncio.open_nursery doesn't exist
+# ANYIO_NO_ERROR # anyio.open_nursery doesn't exist
+import trio
+
+
+async def nursery_no_cancel_point():
+    with trio.CancelScope():  # error: 9, "trio", "CancelScope"
+        async with trio.open_nursery():
+            ...


### PR DESCRIPTION
I was cleaning up old branches in my fork, and it... seems like I never opened a PR for this? Wrote it several months ago, so decided to just rebase and clean it up