### PR TITLE
improve changelog/release handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,10 +62,22 @@ jobs:
             - name: Run tests
               run: python -m tox -e flake8_7 -- --onlyfuzz --no-cov -n auto
 
+    check_release:
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+        if: ${{ ! contains(github.event.issue.labels.*.name, 'skip-release') }}
+        steps:
+            - uses: actions/checkout@v4
+            - name: Set up Python 3
+              uses: actions/setup-python@v5
+            - name: Test changelog & version python tests/test_changelog_and_version.py --ensure-tag
+              run: python3 tests/check_changelog_and_version.py
+
     release:
         runs-on: ubuntu-latest
-        needs: [pyright, test]
-        if: github.repository == 'python-trio/flake8-async' &&  github.ref == 'refs/heads/main'
+        needs: [pyright, test, check_release]
+        if: github.repository == 'python-trio/flake8-async' && github.ref == 'refs/heads/main'
         steps:
             - uses: actions/checkout@v4
             - name: Set up Python 3
@@ -77,5 +89,4 @@ jobs:
                   TWINE_USERNAME: __token__
                   TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
               run: |
-                  python tests/test_changelog_and_version.py --ensure-tag
                   python -m build && twine upload --skip-existing dist/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                python-version: ['3.9', '3.10', '3.11', '3.12', 3.13]
+                python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
             fail-fast: false
         steps:
             - uses: actions/checkout@v4
@@ -66,7 +66,6 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             fail-fast: false
-        if: ${{ ! contains(github.event.issue.labels.*.name, 'skip-release') }}
         steps:
             - uses: actions/checkout@v4
             - name: Set up Python 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,8 +70,8 @@ jobs:
             - uses: actions/checkout@v4
             - name: Set up Python 3
               uses: actions/setup-python@v5
-            - name: Test changelog & version python tests/test_changelog_and_version.py --ensure-tag
-              run: python3 tests/check_changelog_and_version.py
+            - name: Test changelog & version
+              run: python tests/check_changelog_and_version.py
 
     release:
         runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
     python: python3.12
 # pyright requires internet connection to run, which the pre-commit ci app doesn't have.
 # it instead runs in a github action
-# check-relase-changelog is run in CI to be able to access PR labels
+# check-release-changelog is run as a dedicated job
 ci:
     skip: [pyright, check-release-changelog]
 
@@ -107,7 +107,7 @@ repos:
           - id: check-release-changelog
             name: check-release-changelog
             language: system
-            entry: python3 tests/check_changelog_and_version.py --allow-future
+            entry: python3 tests/check_changelog_and_version.py --allow-future-in-changelog
             files: flake8_async/__init__.py|docs/changelog.rst
 
     - repo: meta

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,8 +3,9 @@ default_language_version:
     python: python3.12
 # pyright requires internet connection to run, which the pre-commit ci app doesn't have.
 # it instead runs in a github action
+# check-relase-changelog is run in CI to be able to access PR labels
 ci:
-    skip: [pyright]
+    skip: [pyright, check-release-changelog]
 
 repos:
     - repo: https://github.com/astral-sh/ruff-pre-commit
@@ -100,3 +101,16 @@ repos:
       rev: v1.0.0
       hooks:
           - id: sphinx-lint
+
+    - repo: local
+      hooks:
+          - id: check-release-changelog
+            name: check-release-changelog
+            language: system
+            entry: python3 tests/check_changelog_and_version.py
+            files: flake8_async/__init__.py|docs/changelog.rst
+
+    - repo: meta
+      hooks:
+          - id: check-hooks-apply
+          - id: check-useless-excludes

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -107,7 +107,7 @@ repos:
           - id: check-release-changelog
             name: check-release-changelog
             language: system
-            entry: python3 tests/check_changelog_and_version.py
+            entry: python3 tests/check_changelog_and_version.py --allow-future
             files: flake8_async/__init__.py|docs/changelog.rst
 
     - repo: meta

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,9 +4,12 @@ Changelog
 
 `CalVer, YY.month.patch <https://calver.org/>`_
 
-24.10.3
-=======
+Future
+======
 - :ref:`ASYNC101 <async101>` and :ref:`ASYNC119 <async119>` are now silenced for decorators in :ref:`transform-async-generator-decorators`
+
+24.10.2
+=======
 - :ref:`ASYNC102 <async102>` now also warns about ``await()`` inside ``__aexit__``.
 
 24.10.1

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 
 `CalVer, YY.month.patch <https://calver.org/>`_
 
-24.10.2
+24.10.3
 =======
 - :ref:`ASYNC101 <async101>` and :ref:`ASYNC119 <async119>` are now silenced for decorators in :ref:`transform-async-generator-decorators`
 - :ref:`ASYNC102 <async102>` now also warns about ``await()`` inside ``__aexit__``.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -33,7 +33,7 @@ adding the following to your ``.pre-commit-config.yaml``:
    minimum_pre_commit_version: '2.9.0'
    repos:
    - repo: https://github.com/python-trio/flake8-async
-     rev: 23.2.5
+     rev: 24.10.2
      hooks:
        - id: flake8-async
          # args: [--enable=ASYNC, --disable=ASYNC9, --autofix=ASYNC]

--- a/tests/check_changelog_and_version.py
+++ b/tests/check_changelog_and_version.py
@@ -112,6 +112,9 @@ def update_version() -> None:
 
 
 if __name__ == "__main__":
+    test_last_release_against_changelog()
+    test_version_increments_are_correct()
+
     update_version()
     if "--ensure-tag" in sys.argv:
         ensure_tagged()

--- a/tests/check_changelog_and_version.py
+++ b/tests/check_changelog_and_version.py
@@ -16,7 +16,7 @@ CHANGELOG = ROOT_PATH / "docs" / "changelog.rst"
 README = ROOT_PATH / "README.md"
 INIT_FILE = ROOT_PATH / "flake8_async" / "__init__.py"
 
-ALLOW_FUTURE = "--allow-future" in sys.argv
+ALLOW_FUTURE = "--allow-future-in-changelog" in sys.argv
 
 T = TypeVar("T", bound="Version")
 
@@ -59,10 +59,7 @@ def get_releases() -> Iterable[Version]:
             last_line_was_date = True
         # only allow `Future\n=====` when run in pre-commit
         elif header_pattern.match(line):
-            assert ALLOW_FUTURE, (
-                "FUTURE header with no --allow-future. "
-                "If CI you maybe want the skip-release label."
-            )
+            assert ALLOW_FUTURE, "FUTURE header with no --allow-future-in-changelog. "
             assert last_line is not None
             assert last_line.lower().strip() == "future"
         last_line = line


### PR DESCRIPTION
move changelog&version check to pre-commit and to a separate CI job that skips on skip-release label

Remaining quirks:
1. The job won't re-run automatically on label assignment. Claude is telling me I can get there by splitting up the workflows across files, I'll give that a try later.
2. A CHANGELOG run will fail after getting merged to main, because it loses the label. Not sure how to resolve that neatly; maybe just always pass `--allow-future` if it triggers on `push`.

The test file is kind of ugly now in that it both looks like a pytest file and doesn't. I should probably add some comments at the very least.


EDIT: actually, I shouldn't skip the CI job with the skip-release label - I should just make that pass `--allow-future` as well.
(also the flag is somewhat opaquely named, probs time to do a proper argparse solution).

It's also not great that skip-release doesn't *actually* skip a release attempt, afair we just rely on pushing-the-same-version-again to twine to not do anything.