### PR TITLE
make ASYNC912 and 913 care about cancel points, and ignore schedule points

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,10 @@ Changelog
 
 `CalVer, YY.month.patch <https://calver.org/>`_
 
+25.2.1
+=======
+- :ref:`ASYNC912 <async912>` and :ref:`ASYNC913 <async913>` will now trigger if there's no *cancel* points. This means that :func:`trio.open_nursery`/`anyio.create_task_group` will not silence them on their own, unless they're guaranteed to start tasks.
+
 25.1.1
 =======
 - Add :ref:`ASYNC124 <async124>` async-function-could-be-sync

--- a/docs/rules.rst
+++ b/docs/rules.rst
@@ -197,12 +197,13 @@ _`ASYNC911` : async-generator-no-checkpoint
     Exit, ``yield`` or ``return`` from async iterable with no guaranteed :ref:`checkpoint` since possible function entry (``yield`` or function definition).
 
 _`ASYNC912` : cancel-scope-no-guaranteed-checkpoint
-    A timeout/cancelscope has :ref:`checkpoints <checkpoint>`, but they're not guaranteed to run.
-    Similar to `ASYNC100`_, but it does not warn on trivial cases where there is no checkpoint at all.
+    A timeout/cancelscope has :ref:`cancel points <cancel_point>`, but they're not guaranteed to run.
+    Similar to `ASYNC100`_, but it does not warn on trivial cases where there is no cancel point at all.
     It instead shares logic with `ASYNC910`_ and `ASYNC911`_ for parsing conditionals and branches.
 
 _`ASYNC913` : indefinite-loop-no-guaranteed-checkpoint
     An indefinite loop (e.g. ``while True``) has no guaranteed :ref:`checkpoint <checkpoint>`. This could potentially cause a deadlock.
+    This will also error if there's no guaranteed :ref:`cancel point`, where even though it won't deadlock the loop might become an uncancelable dry-run loop.
 
 .. _autofix-support:
 

--- a/docs/rules.rst
+++ b/docs/rules.rst
@@ -203,7 +203,7 @@ _`ASYNC912` : cancel-scope-no-guaranteed-checkpoint
 
 _`ASYNC913` : indefinite-loop-no-guaranteed-checkpoint
     An indefinite loop (e.g. ``while True``) has no guaranteed :ref:`checkpoint <checkpoint>`. This could potentially cause a deadlock.
-    This will also error if there's no guaranteed :ref:`cancel point`, where even though it won't deadlock the loop might become an uncancelable dry-run loop.
+    This will also error if there's no guaranteed :ref:`cancel point <cancel_point>`, where even though it won't deadlock the loop might become an uncancelable dry-run loop.
 
 .. _autofix-support:
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -33,7 +33,7 @@ adding the following to your ``.pre-commit-config.yaml``:
    minimum_pre_commit_version: '2.9.0'
    repos:
    - repo: https://github.com/python-trio/flake8-async
-     rev: 25.1.1
+     rev: 25.2.1
      hooks:
        - id: flake8-async
          # args: [--enable=ASYNC, --disable=ASYNC9, --autofix=ASYNC]

--- a/flake8_async/__init__.py
+++ b/flake8_async/__init__.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
 
 
 # CalVer: YY.month.patch, e.g. first release of July 2022 == "22.7.1"
-__version__ = "25.1.1"
+__version__ = "25.2.1"
 
 
 # taken from https://github.com/Zac-HD/shed

--- a/tests/autofix_files/async913_trio_anyio.py
+++ b/tests/autofix_files/async913_trio_anyio.py
@@ -1,0 +1,12 @@
+# ARG --enable=ASYNC913
+# AUTOFIX
+# ASYNCIO_NO_ERROR
+
+import trio
+
+
+async def nursery_no_cancel_point():
+    while True:  # ASYNC913: 4
+        await trio.lowlevel.checkpoint()
+        async with trio.open_nursery():
+            pass

--- a/tests/autofix_files/async913_trio_anyio.py.diff
+++ b/tests/autofix_files/async913_trio_anyio.py.diff
@@ -1,0 +1,9 @@
+---
++++
+@@ x,5 x,6 @@
+
+ async def nursery_no_cancel_point():
+     while True:  # ASYNC913: 4
++        await trio.lowlevel.checkpoint()
+         async with trio.open_nursery():
+             pass

--- a/tests/eval_files/async912.py
+++ b/tests/eval_files/async912.py
@@ -125,7 +125,7 @@ async def foo():
     with (res := trio.fail_at(10)):
         ...
     # but saving with `as` does
-    with trio.fail_at(10) as res:  # ASYNC912: 9
+    with trio.fail_at(10) as res2:  # ASYNC912: 9
         if bar():
             await trio.lowlevel.checkpoint()
 
@@ -189,3 +189,10 @@ async def check_yield_logic():
         if bar():
             await trio.lowlevel.checkpoint()
         yield
+
+
+async def nursery_no_cancel_point():
+    with trio.move_on_after(10):  # ASYNC912: 9
+        async with trio.open_nursery():
+            if bar():
+                await trio.lowlevel.checkpoint()

--- a/tests/eval_files/async913_trio_anyio.py
+++ b/tests/eval_files/async913_trio_anyio.py
@@ -1,0 +1,11 @@
+# ARG --enable=ASYNC913
+# AUTOFIX
+# ASYNCIO_NO_ERROR
+
+import trio
+
+
+async def nursery_no_cancel_point():
+    while True:  # ASYNC913: 4
+        async with trio.open_nursery():
+            pass

--- a/tests/test_flake8_async.py
+++ b/tests/test_flake8_async.py
@@ -103,7 +103,14 @@ def diff_strings(first: str, second: str, /) -> str:
 # replaces all instances of `original` with `new` in string
 # unless it's preceded by a `-`, which indicates it's part of a command-line flag
 def replace_library(string: str, original: str = "trio", new: str = "anyio") -> str:
-    return re.sub(rf"(?<!-){original}", new, string)
+    def replace_str(string: str, original: str, new: str) -> str:
+        return re.sub(rf"(?<!-){original}", new, string)
+
+    if original == "trio" and new == "anyio":
+        string = replace_str(string, "trio.open_nursery", "anyio.create_task_group")
+    elif original == "anyio" and new == "trio":
+        string = replace_str(string, "anyio.create_task_group", "trio.open_nursery")
+    return replace_str(string, original, new)
 
 
 def check_autofix(

--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,7 @@ allowlist_externals = make
 changedir = docs
 skip_install = True
 commands =
+    make clean
     make html
 
 # Settings for other tools

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,6 @@ commands =
 # Settings for other tools
 [pytest]
 addopts =
-    --tb=native
     --cov=flake8_async
     --cov-branch
     --cov-report=term-missing:skip-covered


### PR DESCRIPTION
fixes #340 and extends it to ASYNC912 as well

I felt kinda silly realizing the `trio.open_nursery` <-> `anyio.create_task_group` replacement only now, that could clean up eval_files for... 100, 101, 105, 111, 112, 113 & 121 :sweat_smile: 