### PR TITLE
workaround bug generating invalid metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         "Changelog": "https://flake8-async.readthedocs.io/en/latest/changelog.html",
     },
     license="MIT",
+    license_files=[],  # https://github.com/pypa/twine/issues/1216
     description="A highly opinionated flake8 plugin for Trio-related problems.",
     zip_safe=False,
     install_requires=["flake8>=6", "libcst>=1.0.1"],


### PR DESCRIPTION
https://github.com/python-trio/flake8-async/actions/runs/13154402924/job/36708351078#step:5:294 failed because of https://github.com/pypa/twine/issues/1216

Since the problematic actor apparently is setuptools I opted to fix it by setting `license_files`