### PR TITLE
add trio.as_safe_channel to async900 safe decorators

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,10 @@ Changelog
 
 `CalVer, YY.month.patch <https://calver.org/>`_
 
+25.4.4
+======
+- :ref:`ASYNC900 <async900>` now accepts and recommends :func:`trio.as_safe_channel`.
+
 25.4.3
 ======
 - :ref:`ASYNC100 <async100>` can now autofix ``with`` statements with multiple items.

--- a/docs/rules.rst
+++ b/docs/rules.rst
@@ -76,7 +76,9 @@ ASYNC118 : cancelled-class-saved
 
 _`ASYNC119` : yield-in-cm-in-async-gen
    ``yield`` in context manager in async generator is unsafe, the cleanup may be delayed until ``await`` is no longer allowed.
-   We strongly encourage you to read :pep:`533` and use `async with aclosing(...) <https://docs.python.org/3/library/contextlib.html#contextlib.aclosing>`_, or better yet avoid async generators entirely (see `ASYNC900`_ ) in favor of context managers which return an iterable :ref:`channel/stream/queue <channel_stream_queue>`.
+   We strongly encourage you to read :pep:`533` and use `async with aclosing(...) <https://docs.python.org/3/library/contextlib.html#contextlib.aclosing>`_.
+   :func:`trio.as_safe_channel` has been designed to be a drop-in replacement to transform
+   any unsafe async generator into a context manager that uses :ref:`streams <channel_stream_queue>` and safely runs the generator in a background task.
 
 _`ASYNC120` : await-in-except
     Dangerous :ref:`checkpoint` inside an ``except`` block.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -33,7 +33,7 @@ adding the following to your ``.pre-commit-config.yaml``:
    minimum_pre_commit_version: '2.9.0'
    repos:
    - repo: https://github.com/python-trio/flake8-async
-     rev: 25.4.3
+     rev: 25.4.4
      hooks:
        - id: flake8-async
          # args: ["--enable=ASYNC100,ASYNC112", "--disable=", "--autofix=ASYNC"]

--- a/flake8_async/__init__.py
+++ b/flake8_async/__init__.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
 
 
 # CalVer: YY.month.patch, e.g. first release of July 2022 == "22.7.1"
-__version__ = "25.4.3"
+__version__ = "25.4.4"
 
 
 # taken from https://github.com/Zac-HD/shed

--- a/tests/eval_files/async900.py
+++ b/tests/eval_files/async900.py
@@ -1,10 +1,13 @@
 # type: ignore
 # ARG --no-checkpoint-warning-decorator=asynccontextmanager,other_context_manager
 # transform-async-generator-decorators set further down
+
+# trio will also recommend trio.as_safe_channel, see async900_trio
+# NOTRIO
 from contextlib import asynccontextmanager
 
 
-async def foo1():  # ASYNC900: 0, 'asynccontextmanager, fixture, this_is_like_a_context_manager'
+async def foo1():  # ASYNC900: 0, 'contextlib.asynccontextmanager, pytest.fixture, this_is_like_a_context_manager'
     yield
     yield
 
@@ -16,7 +19,7 @@ async def foo2():
 
 @asynccontextmanager
 async def foo3():
-    async def bar():  # ASYNC900: 4, 'asynccontextmanager, fixture, this_is_like_a_context_manager'
+    async def bar():  # ASYNC900: 4, 'contextlib.asynccontextmanager, pytest.fixture, this_is_like_a_context_manager'
         yield
 
     yield
@@ -38,7 +41,7 @@ async def async_fixtures_can_take_arguments():
 
 # no-checkpoint-warning-decorator now ignored
 @other_context_manager
-async def foo5():  # ASYNC900: 0, 'asynccontextmanager, fixture, this_is_like_a_context_manager'
+async def foo5():  # ASYNC900: 0, 'contextlib.asynccontextmanager, pytest.fixture, this_is_like_a_context_manager'
     yield
 
 


### PR DESCRIPTION
fixes #370 
I thought this was gonna be a one-line fix, but ended up getting really messy. There's definitely a cleaner way of implementing this, but it should work... :upside_down_face: 

The reason it gets messy is because `has_decorator`->`_get_identifier` only matches against the last part of an attribute, but I want `trio.as_safe_decorator` in the error message, so the message and the implementation gets a mismatch. The main alternative approach would be to have separate lists of decorators for the error message and the logic.