### PR TITLE
start tagging releases again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,4 +88,5 @@ jobs:
                   TWINE_USERNAME: __token__
                   TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
               run: |
+                  python tests/check_changelog_and_version.py --ensure-tag
                   python -m build && twine upload --skip-existing dist/*


### PR DESCRIPTION
#321 intended to move changelog/version checks to pre-commit, but it *also* removed tagging releases.. without reintroducing that anywhere else.

shoutout to @A5rocks for noticing

We could perhaps do the tagging in pre-commit as well, but that would require contributors to remember to push with `--tag`.

We could go back and "manually" create tags for all past releases since #321, but I'm not sure there's much reason to? But if it's to be done it should be done now before we start to create new tags